### PR TITLE
Add refreshtoken

### DIFF
--- a/app/Actions/Schemas.js
+++ b/app/Actions/Schemas.js
@@ -62,6 +62,7 @@ const User = {
         id: 'string?',
         accessToken: 'string?',
         idToken: 'string?',
+        refreshToken: 'string?',
         email: 'string?',
         firstname: 'string?',
         lastname: 'string?',

--- a/app/Actions/UploadInventory.js
+++ b/app/Actions/UploadInventory.js
@@ -64,7 +64,7 @@ const uploadInventory = () => {
                                         }
                                     })
                                         .catch((err) => {
-                                            alert('There is something wrong')
+                                            alert('There is something wrong – Need to implement common error handling for all API Calls eg: 5xx, 4xx, etc ')
                                             reject()
                                         })
                                 }

--- a/app/Actions/index.js
+++ b/app/Actions/index.js
@@ -17,9 +17,9 @@ const auth0 = new Auth0({ domain: AUTH0_DOMAIN, clientId: AUTH0_CLIENT_ID });
 export const auth0Login = () => {
     return new Promise((resolve, reject) => {
         auth0.webAuth
-            .authorize({ scope: 'openid email profile' })
+            .authorize({ scope: 'offline_access openid email profile' })
             .then(credentials => {
-                const { accessToken, idToken } = credentials;
+                const { accessToken, idToken, refreshToken } = credentials;
                 Realm.open({ schema: [Inventory, Species, Polygons, Coordinates, OfflineMaps, User] })
                     .then(realm => {
                         realm.write(() => {
@@ -27,6 +27,7 @@ export const auth0Login = () => {
                                 id: 'id0001',
                                 accessToken: accessToken,
                                 idToken: 'NO NEED TO STORE',
+                                refreshToken: refreshToken, //Todo if Backend responds 401 with expiration error code that accessToken has expired, client needs to call, Auth0 to retrieve new access token [store accessToken and refreshToken], and redo the request to backend.
                             }, 'modified')
                             getUserInformationFromServer().then(() => {
                                 resolve(true)


### PR DESCRIPTION
Refresh token allows application to get new access token without logging the  user out. When backend returns invalid access token, the client should request a new access token from Auth0 using refresh_token using grant type refresh_token to https://{{auth0_domain}}/oauth/token
endpoint.

Refresh tokens allow the application to maintain session without logging the user out within a certain timeframe.

Todo:

- [ ] Error handling (When backend returns 4xx)to get new access tokens from Auth0 using refresh tokens.

- [ ] Error handling, when refresh tokens expire. [refresh tokens expire in a month, if they are not used. In this case, the application should log out the user and ask to sign in again.]


----

Getting new access token with refresh token
https://github.com/auth0/react-native-auth0#getting-new-access-token-with-refresh-token

```
auth0.auth
  .refreshToken({refreshToken: 'the user refresh_token'})
  .then(console.log)
  .catch(console.error);
```