### PR TITLE
replaced react-native-dotenv with react-native-config to support iOS/Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 import com.android.build.OutputFile
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
           <data
-              android:host="accounts.plant-for-the-planet.org"
+              android:host="@string/AUTH0_DOMAIN"
               android:pathPrefix="/android/${applicationId}/callback"
               android:scheme="${applicationId}" />
           </intent-filter>

--- a/app/Actions/index.js
+++ b/app/Actions/index.js
@@ -1,13 +1,12 @@
 
 import Realm from 'realm';
 import { bugsnag } from '../Utils/index';
-import { MAPBOXGL_ACCCESS_TOKEN } from 'react-native-dotenv';
+import Config from "react-native-config";
 import Auth0 from 'react-native-auth0';
-import { AUTH0_DOMAIN, AUTH0_CLIENT_ID } from 'react-native-dotenv'
 import { Coordinates, OfflineMaps, Polygons, User, Species, Inventory } from './Schemas'
 
 // AUTH0 CONFIG
-const auth0 = new Auth0({ domain: AUTH0_DOMAIN, clientId: AUTH0_CLIENT_ID });
+const auth0 = new Auth0({ domain: Config.AUTH0_DOMAIN, clientId: Config.AUTH0_CLIENT_ID });
 
 
 //  ---------------- AUTH0 ACTIONS START----------------
@@ -54,7 +53,7 @@ export const isLogin = () => {
 
 export const getAreaName = ({ coords }) => {
     return new Promise((resolve, reject) => {
-        fetch(`https://api.mapbox.com/geocoding/v5/mapbox.places/${coords[0]},${coords[1]}.json?types=place&access_token=${MAPBOXGL_ACCCESS_TOKEN}`).then((res) => res.json()).then((res) => {
+        fetch(`https://api.mapbox.com/geocoding/v5/mapbox.places/${coords[0]},${coords[1]}.json?types=place&access_token=${Config.MAPBOXGL_ACCCESS_TOKEN}`).then((res) => res.json()).then((res) => {
             if (res && res.features && res.features[0]) {
                 resolve(res.features[0].place_name)
             } else {

--- a/app/Components/App/index.js
+++ b/app/Components/App/index.js
@@ -5,10 +5,10 @@ import { StateProvider } from '../../Actions/store';
 import { TransitionSpecs, HeaderStyleInterpolators } from '@react-navigation/stack';
 import 'react-native-gesture-handler';
 import { RegisterTree, MultipleTrees, SelectProject, LocateTree, CreatePolygon, TreeInventory, InventoryOverview, MainScreen, SavedAreas, DownloadMap, RegisterSingleTree, SingleTreeOverview, SelectCoordinates, ManageUsers, SelectSpecies } from '../';
-import { MAPBOXGL_ACCCESS_TOKEN } from 'react-native-dotenv';
+import Config from "react-native-config";
 import MapboxGL from '@react-native-mapbox-gl/maps';
 
-MapboxGL.setAccessToken(MAPBOXGL_ACCCESS_TOKEN);
+MapboxGL.setAccessToken(Config.MAPBOXGL_ACCCESS_TOKEN);
 
 const Stack = createStackNavigator();
 

--- a/app/Components/CreatePolygon/MapMarking.js
+++ b/app/Components/CreatePolygon/MapMarking.js
@@ -10,11 +10,11 @@ import { store } from '../../Actions/store';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import Geolocation from '@react-native-community/geolocation';
 import LinearGradient from 'react-native-linear-gradient';
-import { MAPBOXGL_ACCCESS_TOKEN } from 'react-native-dotenv';
+import Config from "react-native-config";
 import { SvgXml } from 'react-native-svg';
 
 
-MapboxGL.setAccessToken(MAPBOXGL_ACCCESS_TOKEN);
+MapboxGL.setAccessToken(Config.MAPBOXGL_ACCCESS_TOKEN);
 
 const infographicText = [
     { heading: 'Alrighty!', subHeading: 'Now, please walk to the next corner and tap continue when ready' },
@@ -119,7 +119,7 @@ class MapMarking extends React.Component {
     addMarker = async (complete) => {
         let { centerCoordinates, geoJSON, activePolygonIndex } = this.state;
         if (this.state.locateTree == 'on-site') {
-            // Check distance 
+            // Check distance
             try {
                 Geolocation.getCurrentPosition(position => {
                     let currentCoords = position.coords;
@@ -267,7 +267,7 @@ class MapMarking extends React.Component {
         const { navigation, inventoryID, setIsCompletePolygon } = this.props;
         const { geoJSON } = this.state;
         await this.addMarker(true)
-        // 
+        //
         let data = { inventory_id: inventoryID, geoJSON: geoJSON };
         setIsCompletePolygon(true)
     }

--- a/app/Components/DownloadMap/index.js
+++ b/app/Components/DownloadMap/index.js
@@ -5,13 +5,13 @@ import { SafeAreaView } from 'react-native'
 import { Colors, Typography } from '_styles';
 import { getAreaName, createOfflineMap, getAllOfflineMaps } from "../../Actions";
 import MapboxGL from '@react-native-mapbox-gl/maps';
-import { MAPBOXGL_ACCCESS_TOKEN } from 'react-native-dotenv';
+import Config from "react-native-config";
 import Geolocation from '@react-native-community/geolocation';
 import { active_marker } from '../../assets/index';
 import { SvgXml } from 'react-native-svg';
 
 
-MapboxGL.setAccessToken(MAPBOXGL_ACCCESS_TOKEN);
+MapboxGL.setAccessToken(Config.MAPBOXGL_ACCCESS_TOKEN);
 
 const DownloadMap = ({ navigation }) => {
     const [isLoaderShow, setIsLoaderShow] = useState(false)

--- a/app/Components/RegisterSingleTree/MapMarking.js
+++ b/app/Components/RegisterSingleTree/MapMarking.js
@@ -10,11 +10,11 @@ import { store } from '../../Actions/store';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import Geolocation from '@react-native-community/geolocation';
 import LinearGradient from 'react-native-linear-gradient';
-import { MAPBOXGL_ACCCESS_TOKEN } from 'react-native-dotenv';
+import Config from "react-native-config";
 import { SvgXml } from 'react-native-svg';
 
 
-MapboxGL.setAccessToken(MAPBOXGL_ACCCESS_TOKEN);
+MapboxGL.setAccessToken(Config.MAPBOXGL_ACCCESS_TOKEN);
 
 const infographicText = [
     { heading: 'Alrighty!', subHeading: 'Now, please walk to the next corner and tap continue when ready' },
@@ -90,7 +90,7 @@ class MapMarking extends React.Component {
 
     addMarker = async () => {
         let { centerCoordinates, geoJSON, activePolygonIndex } = this.state;
-        // Check distance 
+        // Check distance
         try {
             Geolocation.getCurrentPosition(position => {
                 let currentCoords = position.coords;

--- a/app/Components/SelectCoordinates/index.js
+++ b/app/Components/SelectCoordinates/index.js
@@ -10,11 +10,11 @@ import { store } from '../../Actions/store';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import Geolocation from '@react-native-community/geolocation';
 import LinearGradient from 'react-native-linear-gradient';
-import { MAPBOXGL_ACCCESS_TOKEN } from 'react-native-dotenv';
+import Config from "react-native-config";
 import { SvgXml } from 'react-native-svg';
 
 
-MapboxGL.setAccessToken(MAPBOXGL_ACCCESS_TOKEN);
+MapboxGL.setAccessToken(Config.MAPBOXGL_ACCCESS_TOKEN);
 
 const infographicText = [
     { heading: 'Alrighty!', subHeading: 'Now, please walk to the next corner and tap continue when ready' },
@@ -77,7 +77,7 @@ class SelectCoordinates extends React.Component {
 
     addMarker = async () => {
         let { centerCoordinates } = this.state;
-        // Check distance 
+        // Check distance
         try {
             Geolocation.getCurrentPosition(position => {
                 let currentCoords = position.coords;

--- a/app/Utils/index.js
+++ b/app/Utils/index.js
@@ -1,7 +1,7 @@
 import { Client } from 'bugsnag-react-native';
-import { BUGSNAP_CLIENT_KEY } from 'react-native-dotenv'
+import Config from "react-native-config";
 
 const APLHABETS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-const bugsnag = new Client(BUGSNAP_CLIENT_KEY);
+const bugsnag = new Client(Config.BUGSNAP_CLIENT_KEY);
 
 export { APLHABETS, bugsnag };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  presets: ['module:metro-react-native-babel-preset', 'module:react-native-dotenv'],
+  presets: ['module:metro-react-native-babel-preset'],
 };

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -262,6 +262,10 @@ PODS:
     - React
   - react-native-camera/RN (3.33.0):
     - React
+  - react-native-config (1.3.3):
+    - react-native-config/App (= 1.3.3)
+  - react-native-config/App (1.3.3):
+    - React
   - react-native-document-picker (3.4.0):
     - React
   - react-native-geolocation (2.0.2):
@@ -416,6 +420,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-camera (from `../node_modules/react-native-camera`)
+  - react-native-config (from `../node_modules/react-native-config`)
   - react-native-document-picker (from `../node_modules/react-native-document-picker`)
   - "react-native-geolocation (from `../node_modules/@react-native-community/geolocation`)"
   - "react-native-mapbox-gl (from `../node_modules/@react-native-mapbox-gl/maps`)"
@@ -504,6 +509,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-camera:
     :path: "../node_modules/react-native-camera"
+  react-native-config:
+    :path: "../node_modules/react-native-config"
   react-native-document-picker:
     :path: "../node_modules/react-native-document-picker"
   react-native-geolocation:
@@ -595,6 +602,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
   react-native-camera: b95731eb91691ae7c8acdd496a1ef051ae2e65ff
+  react-native-config: 9a061347e0136fdb32d43a34d60999297d672361
   react-native-document-picker: d694111879537cec2c258a1dcd2243d9df746824
   react-native-geolocation: cbd9d6bd06bac411eed2671810f454d4908484a8
   react-native-mapbox-gl: 77b87a1dd2d7b41b6b77018c0f3bed5f8ee55c81

--- a/package-lock.json
+++ b/package-lock.json
@@ -4608,14 +4608,6 @@
         }
       }
     },
-    "babel-plugin-dotenv": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dotenv/-/babel-plugin-dotenv-0.1.1.tgz",
-      "integrity": "sha1-nI+upnp8A0/n6UCZGHqy51c0ALw=",
-      "requires": {
-        "dotenv": "^2.0.0"
-      }
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -5617,11 +5609,6 @@
         "dom-serializer": "0",
         "domelementtype": "1"
       }
-    },
-    "dotenv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
-      "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -12596,18 +12583,15 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-native-config": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.3.3.tgz",
+      "integrity": "sha512-uc84IFVLqu2dC7Zutg3OlK6RZYvJlGbIdi0v1ZxjUhU379Nz9IkZR1t8J1L5QSnGV8885mtwWDPJRdQyVNFsAw=="
+    },
     "react-native-document-picker": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/react-native-document-picker/-/react-native-document-picker-3.4.0.tgz",
       "integrity": "sha512-YdjiiElDdvOj55IDPNJ0kxXxzDRWyDymV/iYZJt34ueRWWFLIff+DymSjBc0QljrIFv7pODws2lo81+5Y0ww0w=="
-    },
-    "react-native-dotenv": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/react-native-dotenv/-/react-native-dotenv-0.2.0.tgz",
-      "integrity": "sha1-MRVRy2o1o9z+3mSL3tVcDj7OV50=",
-      "requires": {
-        "babel-plugin-dotenv": "0.1.1"
-      }
     },
     "react-native-extended-stylesheet": {
       "version": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-native-awesome-alerts": "^1.3.1",
     "react-native-camera": "git+https://git@github.com/react-native-community/react-native-camera.git",
     "react-native-document-picker": "^3.4.0",
-    "react-native-dotenv": "^0.2.0",
+    "react-native-config": "^1.3.3",
     "react-native-extended-stylesheet": "^0.12.0",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "^1.6.1",


### PR DESCRIPTION
Related to #31

Changes in this pull request:
- removed react-native-dotenv
- added react-native-config
- load AUTH0_DOMAIN in AndroidManifest.xml from .env file

I have not yet added support for multiple .env.* files and Android flavors and different Xcode schemes to build a develop, staging or production app. But that's also possible now. Read https://github.com/luggit/react-native-config for using it.

@sagararyal @haideralishah this branch has conflict with https://github.com/Plant-for-the-Planet-org/treemapper/pull/17 of course as there had already been made adaptions is that PR which also have to be converted. Once this PR is merged to develop, I would merge develop into https://github.com/Plant-for-the-Planet-org/treemapper/pull/17 and fix the merge conflicts right in that PR. That's the best way I can think of.