### PR TITLE
upgrade react-native-camera and Cocoapods

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -254,13 +254,13 @@ PODS:
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
   - React-jsinspector (0.63.2)
-  - react-native-camera (3.35.0):
+  - react-native-camera (3.36.0):
     - React
-    - react-native-camera/RCT (= 3.35.0)
-    - react-native-camera/RN (= 3.35.0)
-  - react-native-camera/RCT (3.35.0):
+    - react-native-camera/RCT (= 3.36.0)
+    - react-native-camera/RN (= 3.36.0)
+  - react-native-camera/RCT (3.36.0):
     - React
-  - react-native-camera/RN (3.35.0):
+  - react-native-camera/RN (3.36.0):
     - React
   - react-native-config (1.3.3):
     - react-native-config/App (= 1.3.3)
@@ -358,7 +358,7 @@ PODS:
     - React-Core
   - RNCMaskedView (0.1.10):
     - React
-  - RNDateTimePicker (2.4.0):
+  - RNDateTimePicker (2.6.0):
     - React
   - RNFS (2.16.6):
     - React
@@ -606,7 +606,7 @@ SPEC CHECKSUMS:
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
-  react-native-camera: 9dd96065b956306de03ef2a2efc3583019f95941
+  react-native-camera: 8a63c369af9383fcedea9a73fe234c7efb234d24
   react-native-config: 9a061347e0136fdb32d43a34d60999297d672361
   react-native-document-picker: d694111879537cec2c258a1dcd2243d9df746824
   react-native-geolocation: cbd9d6bd06bac411eed2671810f454d4908484a8
@@ -626,7 +626,7 @@ SPEC CHECKSUMS:
   RealmJS: 16eb794ce5490cf2981372167ac6a6c45f989a4e
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
   RNCMaskedView: f5c7d14d6847b7b44853f7acb6284c1da30a3459
-  RNDateTimePicker: 39a3987baca0848368f71f02c45bf6e1e61041c0
+  RNDateTimePicker: 8784fb27ddd12a9f0eaf6d994bfe3892f0f319cf
   RNFS: 2bd9eb49dc82fa9676382f0585b992c424cd59df
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNLocalize: c388679af021ddd6069c215f7fdd2acf4e77ede5
@@ -640,4 +640,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 5de3e4bfdf092da8b6558bee0faa625368e6dc3d
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -12701,8 +12701,9 @@
       }
     },
     "react-native-camera": {
-      "version": "git+https://git@github.com/react-native-community/react-native-camera.git#7706ccbea7cb53d4573ff93e7308cccf85d77fb9",
-      "from": "git+https://git@github.com/react-native-community/react-native-camera.git",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/react-native-camera/-/react-native-camera-3.36.0.tgz",
+      "integrity": "sha512-TdpT4q9gG4waDsnpKliFpmRnUMuBd3sHBlLBTlIFPPnxayVA9Z2E1yHuR10TCnuGI5a0i0wyCeLFOPJbMg70IQ==",
       "requires": {
         "prop-types": "^15.6.2"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-native": "0.63.2",
     "react-native-auth0": "^2.5.0",
     "react-native-awesome-alerts": "^1.3.1",
-    "react-native-camera": "git+https://git@github.com/react-native-community/react-native-camera.git",
+    "react-native-camera": "^3.36.0",
     "react-native-config": "^1.3.3",
     "react-native-document-picker": "^3.4.0",
     "react-native-extended-stylesheet": "^0.12.0",


### PR DESCRIPTION
Fixes #

Changes in this pull request:
- upgraded react-native-camera to version 3.36.0
- upgraded Cocoapods to 1.93.0
- implicitly upgraded RNDateTimePicker Pod

@
