### PR TITLE
allowing sampling only species that has been planted

### DIFF
--- a/app/components/AdditionalData/AdditionalDataForm.tsx
+++ b/app/components/AdditionalData/AdditionalDataForm.tsx
@@ -1,4 +1,4 @@
-import { CommonActions, useNavigation } from '@react-navigation/native';
+import { CommonActions, useNavigation, useRoute } from '@react-navigation/native';
 import i18next from 'i18next';
 import React, { useContext, useEffect, useState } from 'react';
 import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
@@ -38,9 +38,13 @@ const AdditionalDataForm = (props: IAdditionalDataFormProps) => {
 
   const navigation = useNavigation();
 
+  const route = useRoute();
+
   useEffect(() => {
     const unsubscribe = navigation.addListener('focus', () => {
-      if (inventoryState.inventoryID) {
+      if (route?.params?.redirectToOverview) {
+        navigation.navigate('InventoryOverview');
+      } else if (inventoryState.inventoryID) {
         let data = { inventory_id: inventoryState.inventoryID, lastScreen: 'AdditionalDataForm' };
         updateLastScreen(data);
         setLoading(true);

--- a/app/components/Common/ImageCapturing/index.js
+++ b/app/components/Common/ImageCapturing/index.js
@@ -163,11 +163,20 @@ const ImageCapturing = ({
                   inventory.completedSampleTreesCount + 1
                 } inventory_id: ${inventory.inventory_id}`,
               });
-              updateLastScreen({
-                inventory_id: inventory.inventory_id,
-                lastScreen: 'SelectSpecies',
-              });
-              navigation.navigate('SelectSpecies');
+
+              if (inventory.sampleTrees[inventory.completedSampleTreesCount]?.specieId) {
+                updateLastScreen({
+                  inventory_id: inventory.inventory_id,
+                  lastScreen: 'SelectSpecies',
+                });
+                navigation.navigate('SelectSpecies');
+              } else {
+                updateLastScreen({
+                  inventory_id: inventory.inventory_id,
+                  lastScreen: 'SpecieSampleTree',
+                });
+                navigation.navigate('SpecieSampleTree');
+              }
             })
             .catch((err) => {
               dbLog.error({

--- a/app/components/Common/TreeCountModal/index.js
+++ b/app/components/Common/TreeCountModal/index.js
@@ -1,5 +1,5 @@
 import i18next from 'i18next';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Image,
   KeyboardAvoidingView,
@@ -16,16 +16,25 @@ import { Colors, CommonStyles } from '_styles';
 import { species_default } from '../../../assets';
 import { Header } from '../';
 import Ionicons from 'react-native-vector-icons/Ionicons';
+import { getScientificSpeciesById } from '../../../repositories/species';
 
 export default function TreeCountModal({
   showTreeCountModal,
+  setShowTreeCountModal,
   activeSpecie,
   setTreeCount,
   treeCount,
   onPressTreeCountNextBtn,
-  setShowTreeCountModal,
 }) {
   let specieName = showTreeCountModal ? activeSpecie?.aliases : '';
+  const [specie, setSpecie] = useState();
+  useEffect(() => {
+    if (activeSpecie?.id && showTreeCountModal) {
+      getScientificSpeciesById(activeSpecie?.id).then((specie) => {
+        setSpecie(specie);
+      });
+    }
+  }, [activeSpecie]);
   return (
     <Modal visible={showTreeCountModal} transparent={true}>
       <View
@@ -43,14 +52,20 @@ export default function TreeCountModal({
             }}
           />
           <Image
-            source={activeSpecie?.image ? { uri: `${activeSpecie.image}` } : species_default}
+            source={
+              activeSpecie?.image
+                ? { uri: `${activeSpecie.image}` }
+                : specie?.image
+                  ? { uri: `${specie?.image}` }
+                  : species_default
+            }
             style={{
               alignSelf: 'center',
               marginVertical: 20,
               width: 150,
               height: 100,
               borderRadius: 5,
-              resizeMode: activeSpecie?.image ? null : 'contain',
+              resizeMode: activeSpecie?.image || specie?.image ? null : 'contain',
             }}
           />
           <Header
@@ -80,7 +95,7 @@ export default function TreeCountModal({
             {i18next.t('label.select_species_modal_label')}
           </Text>
           <TextInput
-            value={treeCount.toString()}
+            value={treeCount?.toString()}
             style={CommonStyles.bottomInputText}
             autoFocus
             placeholderTextColor={Colors.TEXT_COLOR}

--- a/app/components/Navigator/MainNavigator.tsx
+++ b/app/components/Navigator/MainNavigator.tsx
@@ -40,6 +40,7 @@ import SelectElement from '../AdditionalData/SelectElement';
 import AdditionalDataForm from '../AdditionalData/AdditionalDataForm';
 import AddMetadata from '../AdditionalData/AddMetadata';
 import AdditionalDataSettings from '../AdditionalData/AdditionalDataSettings';
+import { AddMeasurements } from '../SelectSpecies/AddMeasurements';
 
 const Stack = createStackNavigator();
 
@@ -123,6 +124,7 @@ export default function MainNavigator() {
         options={MyTransition}
       />
       <Stack.Screen name="SpecieSampleTree" component={SpecieSampleTree} options={MyTransition} />
+      <Stack.Screen name="AddMeasurements" component={AddMeasurements} options={MyTransition} />
     </Stack.Navigator>
   );
 }

--- a/app/components/SampleTrees/SampleTreesCount.js
+++ b/app/components/SampleTrees/SampleTreesCount.js
@@ -109,7 +109,7 @@ export default function SampleTreesCount() {
 
   // used for navigation
   const navigation = useNavigation();
-  const dimensionRegex = /^\d{0,2}(\.\d{0})?$/;
+  const dimensionRegex = /^\d{0,3}(\.\d{0})?$/;
 
   // sets the sample tree count in the inventory schema and the navigates to map marking of sample trees
   const onPressContinue = () => {

--- a/app/components/SampleTrees/SampleTreesReview.js
+++ b/app/components/SampleTrees/SampleTreesReview.js
@@ -2,7 +2,7 @@ import i18next from 'i18next';
 import React, { useEffect, useState, useContext } from 'react';
 import { FlatList, Image, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import RNFS from 'react-native-fs';
-import { CommonActions } from '@react-navigation/native';
+import { CommonActions, useIsFocused } from '@react-navigation/native';
 import FAIcon from 'react-native-vector-icons/FontAwesome';
 import { Colors, Typography } from '_styles';
 import { single_tree_png } from '../../assets';
@@ -70,7 +70,7 @@ export default function SampleTreesReview({ sampleTrees, totalSampleTrees, navig
   const [countryCode, setCountryCode] = useState('');
   const [inventory, setInventory] = useState();
   const { state } = useContext(InventoryContext);
-
+  const isFocused = useIsFocused();
   useEffect(() => {
     getUserInformation().then((data) => {
       setCountryCode(data.country);
@@ -78,13 +78,16 @@ export default function SampleTreesReview({ sampleTrees, totalSampleTrees, navig
     getInventory({ inventoryID: state.inventoryID }).then((inventoryData) => {
       setInventory(inventoryData);
     });
-  }, []);
+  }, [isFocused]);
 
   const addSampleTree = () => {
     updateInventory({
       inventory_id: state.inventoryID,
       inventoryData: {
-        sampleTreesCount: inventory.sampleTreesCount + 1,
+        sampleTreesCount:
+          inventory.sampleTreesCount === inventory.completedSampleTreesCount
+            ? inventory.sampleTreesCount + 1
+            : inventory.sampleTreesCount,
       },
     }).then(() => {
       let data = {

--- a/app/components/SelectSpecies/AddMeasurements.tsx
+++ b/app/components/SelectSpecies/AddMeasurements.tsx
@@ -213,7 +213,6 @@ export const AddMeasurements = ({ setIsShowTreeMeasurement }) => {
   };
 
   const postMeasurementUpdate = () => {
-    setIsShowTreeMeasurement(false);
     setDiameter('');
     setHeight('');
     setTagId('');

--- a/app/languages/en/user/inventoryOverview.json
+++ b/app/languages/en/user/inventoryOverview.json
@@ -10,6 +10,7 @@
   "inventory_overview_export_json_message": "Choose target for export",
   "inventory_overview_export_json_title": "GeoJSON export",
   "inventory_overview_add_species": "Planted Species",
+  "inventory_overview_add_sample_tree": "Sample Trees",
   "inventory_overview_header_text": "Review",
   "inventory_overview_sub_header": "Trees will be added to your inventory to sync when you have internet.",
   "inventory_overview_left_text": "Plant Date",

--- a/app/languages/en/user/treeReview.json
+++ b/app/languages/en/user/treeReview.json
@@ -30,5 +30,9 @@
   "tree_review_continue_to_additional_data": "Continue to additional data",
   "skip": "Skip & Save",
   "add_more_sample_trees": "Add more Sample Trees",
-  "recommend_at_least_one_sample": "Some of the planted species are not sampled. We recommend you to sample at least one tree for each planted species."
+  "recommend_at_least_one_sample": "Some of the planted species are not sampled. We recommend you to sample at least one tree for each planted species.",
+  "no_species_found": "No species found",
+  "at_least_one_species": "You should have at least 1 species before adding Sample Trees",
+  "need_more_sample_trees": "Need more Sample Trees",
+  "at_least_five_sample_trees": "You should add at least 5 Sample Trees"
 }

--- a/app/repositories/inventory.js
+++ b/app/repositories/inventory.js
@@ -913,7 +913,6 @@ export const updateInventory = ({ inventory_id, inventoryData }) => {
           logStack: JSON.stringify(err),
         });
         reject(err);
-        console.log(err, 'err');
         bugsnag.notify(err);
       });
   });

--- a/app/utils/getSampleSpecies.js
+++ b/app/utils/getSampleSpecies.js
@@ -1,0 +1,16 @@
+export const getNotSampledSpecies = (inventory) => {
+  let sampledSpecies = [];
+  let plantedSpecies = [];
+  let notSampledSpecies = [];
+  inventory.sampleTrees.forEach((sampleTree) => {
+    sampledSpecies.push(sampleTree.specieId);
+  });
+  inventory.species.forEach((specie) => {
+    plantedSpecies.push(specie.id);
+  });
+  sampledSpecies = [...new Set(sampledSpecies)];
+  plantedSpecies.forEach((specie) =>
+    sampledSpecies.includes(specie) ? notSampledSpecies : notSampledSpecies.push(specie),
+  );
+  return notSampledSpecies;
+};


### PR DESCRIPTION

Changes in this pull request:

- Displaying only Planted species after the image is captured in the Sample Trees flow
- On the Inventory Overview Screen, species can be deleted. If species have the sample Trees then those SampleTrees will also be deleted after giving a warning
- If after deletion of SampleTrees, the count goes below 5 (or even 0) the sampleTreesCount will be set to 5 (as a minimum of 5 Sample Trees is required).
- Button to add the Sample Trees is provided in case all sample trees got deleted
- Tree Count can be changed from the Inventory Overview Screen as well
- Handling of cases of less than 5 sample Trees, 0 planted species, at least one sample tree for each planted species on the 'Save' button

@norbertschuler 
