### PR TITLE
explicitly specify read timeout for downloading species

### DIFF
--- a/app/utils/updateAndSyncLocalSpecies.js
+++ b/app/utils/updateAndSyncLocalSpecies.js
@@ -273,6 +273,8 @@ const downloadAndUpdateSpecies = (zipFilePath, jsonFilePath, setUpdatingSpeciesS
     RNFS.downloadFile({
       fromUrl: `${protocol}://${url}/treemapper/scientificSpeciesArchive`,
       toFile: zipFilePath,
+      readTimeout: 300*1000, // allow max 5 minutes for downloading
+      background: false,
       begin: () => {
         setUpdatingSpeciesState('DOWNLOADING');
       },


### PR DESCRIPTION
Fixes problem with species download from develop or staging backend.

Changes in this pull request:
- explicitly specify read timeout for downloading species
- no background task for iOS due to https://github.com/itinance/react-native-fs/issues/656

@ankitecd 
