### PR TITLE
Update Android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,9 +6,11 @@ buildscript {
         minSdkVersion = 19
         compileSdkVersion = 29
         targetSdkVersion = 29
+        androidXVersion = "1.2.0"
     }
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -21,6 +23,8 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
+        mavenCentral()
         mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
@@ -31,11 +35,10 @@ allprojects {
             url("$rootDir/../node_modules/jsc-android/dist")
         }
 
-        google()
-        jcenter()
         // ADD THIS
         maven { url 'https://maven.google.com' }
         maven { url 'https://www.jitpack.io' }
 
+        jcenter()
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -27,4 +27,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.jvmargs=-Xmx2048m
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.62.0
+FLIPPER_VERSION=0.87.0


### PR DESCRIPTION
Fixes broken Android build process

Changes in this pull request:
- added mavenCentral to replace jcenter
- updated Flipper to newer version
- added explicit androidXVersion
