### PR TITLE
upgrade mapbox iOS SDK

### DIFF
--- a/.github/workflows/macos_build_ios.yml
+++ b/.github/workflows/macos_build_ios.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Select Xcode
       run: |
         echo "Default version:" `xcode-select -p`
-        sudo xcode-select -s /Applications/Xcode_12.4.app
+        sudo xcode-select -s /Applications/Xcode_13.1.app
         echo "Selected version:" `xcode-select -p`
 
     - name: Upgrade npm to latest version
@@ -102,6 +102,16 @@ jobs:
         echo "CDN_URL=$CDN_URL" >> .env
         echo "WEB_APP_URL=$WEB_APP_URL" >> .env
         cp .env .env.staging
+
+    - name: Create .netrc file for Mapbox SDK download
+      env:
+        MAPBOXGL_DOWNLOAD_TOKEN: ${{ secrets.MAPBOXGL_DOWNLOAD_TOKEN }}
+      run: |
+        touch ~/.netrc
+        chmod 600 ~/.netrc
+        echo "machine api.mapbox.com" >> ~/.netrc
+        echo "login mapbox" >> ~/.netrc
+        echo "password $MAPBOXGL_DOWNLOAD_TOKEN" >> ~/.netrc
 
     # - name: Caching Pods
     #   uses: actions/cache@v1

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -6,6 +6,8 @@ platform :ios, '11.0'
 target 'treemapper' do
   config = use_native_modules!
 
+  $ReactNativeMapboxGLIOSVersion = '~> 6.1'
+
   use_react_native!(
     :path => config[:reactNativePath],
     # to enable hermes on iOS, change `false` to `true` and then install pods

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -87,9 +87,9 @@ PODS:
   - jail-monkey (2.6.0):
     - React-Core
   - libevent (2.1.12)
-  - Mapbox-iOS-SDK (5.9.0):
-    - MapboxMobileEvents (= 0.10.2)
-  - MapboxMobileEvents (0.10.2)
+  - Mapbox-iOS-SDK (6.4.1):
+    - MapboxMobileEvents (~> 0.10.12)
+  - MapboxMobileEvents (0.10.13)
   - OpenSSL-Universal (1.1.180)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -308,17 +308,17 @@ PODS:
   - react-native-get-random-values (1.7.0):
     - React-Core
   - react-native-mapbox-gl (8.5.0):
-    - Mapbox-iOS-SDK (~> 5.9.0)
+    - Mapbox-iOS-SDK (~> 6.1)
     - React
     - React-Core
     - react-native-mapbox-gl/DynamicLibrary (= 8.5.0)
     - react-native-mapbox-gl/StaticLibraryFixer (= 8.5.0)
   - react-native-mapbox-gl/DynamicLibrary (8.5.0):
-    - Mapbox-iOS-SDK (~> 5.9.0)
+    - Mapbox-iOS-SDK (~> 6.1)
     - React
     - React-Core
   - react-native-mapbox-gl/StaticLibraryFixer (8.5.0):
-    - Mapbox-iOS-SDK (~> 5.9.0)
+    - Mapbox-iOS-SDK (~> 6.1)
     - React
     - React-Core
   - react-native-netinfo (6.0.4):
@@ -688,8 +688,8 @@ SPEC CHECKSUMS:
   glog: 5337263514dd6f09803962437687240c5dc39aa4
   jail-monkey: 07b83767601a373db876e939b8dbf3f5eb15f073
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  Mapbox-iOS-SDK: a5915700ec84bc1a7f8b3e746d474789e35b7956
-  MapboxMobileEvents: 2bc0ca2eedb627b73cf403258dce2b2fa98074a6
+  Mapbox-iOS-SDK: f870f83cbdc7aa4a74afcee143aafb0dae390c82
+  MapboxMobileEvents: e78db24b348f48e41e5895be7dc16e5b1bb43562
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: 3cc065b52aa18db729268b9bd78a2feffb4d0f91
@@ -708,7 +708,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: f1b5398801b332c77bc62ae0eae2116f49bdff26
   react-native-geolocation-service: 7c9436da6dfdecd9526c62eac62ea2bc3f0cc8ea
   react-native-get-random-values: 237bffb1c7e05fb142092681531810a29ba53015
-  react-native-mapbox-gl: 955d2c064b56ef058b9cc0fbbf6cf743b05c928e
+  react-native-mapbox-gl: 70b58464609b34d1480381bc46e208453264f91e
   react-native-netinfo: 1c7676413ab265759c7b3da205efab163f5366ef
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   React-perflogger: fcac6090a80e3d967791b4c7f1b1a017f9d4a398
@@ -745,6 +745,6 @@ SPEC CHECKSUMS:
   Yoga: 2b4a01651f42a32f82e6cef3830a3ba48088237f
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 2dbbfcaf0bbdcc18ab9379994f4a499b750aafb7
+PODFILE CHECKSUM: e30ab6c2753b27ca80a180bc81984296b3a49173
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Fixes #534

Changes in this pull request:
- upgrade mapbox [iOS SDK](https://github.com/react-native-mapbox-gl/maps/blob/master/ios/install.md) to a version higher 6.0 requiring a token to get downloaded

This demand creating a `.netrc` file in your home directory containing the following (replace the placeholder `SECRET_TOKEN` with a the real secret token from Mapbox asking me for it):
```
machine api.mapbox.com
login mapbox
password SECRET_TOKEN
```

To-Do: We could of course also upgrade the [Android SDK](https://github.com/react-native-mapbox-gl/maps/blob/master/android/install.md) to > 6.