### PR TITLE
Fix: sample tree being marked on same location

### DIFF
--- a/app/languages/en/user/locateTree.json
+++ b/app/languages/en/user/locateTree.json
@@ -24,5 +24,6 @@
   "locate_tree_unable_to_retrieve_location": "Unable to retrieve location.",
   "distance_more_than_100_meter": "Current marker position is more than 100 meter from original coordinate location.",
   "cannot_update_polygon": "Cannot update polygon!",
-  "sample_trees_outside_polygon": "Sample trees are falling outside the polygon. Please check and update the polygon."
+  "sample_trees_outside_polygon": "Sample trees are falling outside the polygon. Please check and update the polygon.",
+  "cannot_mark_sample_tree_under_distance": "Cannot mark sample tree under 30cm of another sample tree."
 }


### PR DESCRIPTION
Fixed a bug on production where sample tree markers can be marked at exact same location: https://www.notion.so/plantfortheplanet/Norbert-s-Dashboard-0f5f777c55df4cafbd376b9afaa21a42?p=f2415e164c3e4dca9b012c90033fbae8

Changes in this pull request:
- added validation of 30cm distance between 2 sample markers
