### PR TITLE
fixed broken layout for additional data introduction screen

### DIFF
--- a/app/components/AdditionalData/Form.tsx
+++ b/app/components/AdditionalData/Form.tsx
@@ -141,11 +141,11 @@ function Form({
             !isInitialLoading &&
             Array.isArray(filteredForm) &&
             filteredForm.length === 0 && (
-              <>
+              <View style={[styles.formMessageContainer]}>
                 <Text style={styles.title}>{i18next.t('label.get_started_forms')}</Text>
                 <Text style={styles.desc}>{i18next.t('label.get_started_forms_description')}</Text>
                 <PrimaryButton btnText={i18next.t('label.create_form')} onPress={addNewForm} />
-              </>
+              </View>
             )}
           <InputModal
             isOpenModal={showInputModal}
@@ -186,6 +186,8 @@ const styles = StyleSheet.create({
   },
   formMessageContainer: {
     flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
     paddingHorizontal: 25,
   },
   title: {


### PR DESCRIPTION
Changes in this pull request:
- fixed broken layout for additional data introduction screen

before & after using the same styles as for the meta data screen:

![Screenshot_20220130-141032](https://user-images.githubusercontent.com/1532418/151701284-84aca5f3-d975-4f51-8f9e-dc4ef6478d74.png)![Screenshot_20220130-140912](https://user-images.githubusercontent.com/1532418/151701283-e1df0bf8-922e-45be-b6e7-3dba3bf8754c.png)

 