### PR TITLE
Hotfix/maplibre android

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "TreeMapper",
     "slug": "treemapper",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/src/components/map/ClusteredShapeSource.tsx
+++ b/src/components/map/ClusteredShapeSource.tsx
@@ -40,10 +40,12 @@ const ClusteredShapeSource = (props: Props) => {
             0.2],
           fillColor: FillColor
         }}
+        filter={['all', ["!=", ["geometry-type"], "Point"]]}
       />
       <MapLibreGL.LineLayer
         id={'polygon_cluster_line'}
         style={{ ...polyline, lineColor: FillColor }}
+        filter={['all', ["!=", ["geometry-type"], "Point"]]}
       />
       <MapLibreGL.CircleLayer id={'singleEntire'} style={{ circleOpacity: 0.8, circleColor: FillColor }} filter={['all', ["==", ["geometry-type"], "Point"]]} />
     </MapLibreGL.ShapeSource>

--- a/src/components/map/SingleInterventionSource.tsx
+++ b/src/components/map/SingleInterventionSource.tsx
@@ -51,10 +51,12 @@ const SingleInterventionSource = (props: Props) => {
       <MapLibreGL.FillLayer
         id={'poly_shape_source_fill'} // Unique ID for active FillLayer
         style={{ fillOpacity: 0.5, fillColor: FillColor }}
+        filter={['all', ["!=", ["geometry-type"], "Point"]]}
       />
       <MapLibreGL.LineLayer
         id={'poly_line_shape_source'}
         style={{ ...polyline, lineColor: FillColor }}
+        filter={['all', ["!=", ["geometry-type"], "Point"]]}
       />
       <MapLibreGL.CircleLayer id={'singleEsntire'} style={{ circleOpacity: 0.8, circleColor: FillColor }} filter={['all', ["==", ["geometry-type"], "Point"]]} />
 


### PR DESCRIPTION
A user reported an issue where clicking on a point location caused the app to crash. This was due to the latest MapLibre SDK added in the previous build, which introduced the problem. The new SDK requires strict adherence to guidelines for adding filters in the layers. This issue has been resolved.

I have already released the updated Android version (2.0.5) as the user requested an urgent fix. I’ve also uploaded the latest version to TestFlight, which I am currently testing. Once testing is complete, I will submit it for review.

@norbertschuler 