### PR TITLE
fix(web): make date range pickers require start-then-end selection

### DIFF
--- a/apps/web/src/component/header/DateRangePicker.tsx
+++ b/apps/web/src/component/header/DateRangePicker.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { CalendarIcon } from 'lucide-react'
-import { format, parseISO, startOfDay, endOfDay, startOfWeek, endOfWeek, startOfMonth, endOfMonth, startOfYear, endOfYear } from 'date-fns'
+import { format, parseISO, startOfDay, endOfDay, startOfWeek, endOfWeek, startOfMonth, endOfMonth, startOfYear, endOfYear, startOfQuarter, endOfQuarter, subQuarters, subYears } from 'date-fns'
 import type { DateRange } from 'react-day-picker'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Calendar } from '@/components/ui/calendar'
@@ -16,6 +16,8 @@ const PRESETS = [
   { label: 'This Week',  get: () => ({ from: startOfWeek(new Date()), to: endOfWeek(new Date()) }) },
   { label: 'This Month', get: () => ({ from: startOfMonth(new Date()), to: endOfMonth(new Date()) }) },
   { label: 'This Year',  get: () => ({ from: startOfYear(new Date()), to: endOfYear(new Date()) }) },
+  { label: 'Last Quarter', get: () => ({ from: startOfQuarter(subQuarters(new Date(), 1)), to: endOfQuarter(subQuarters(new Date(), 1)) }) },
+  { label: 'Last Year',  get: () => ({ from: startOfYear(subYears(new Date(), 1)), to: endOfYear(subYears(new Date(), 1)) }) },
 ] as const
 
 export default function DateRangePicker() {
@@ -23,35 +25,39 @@ export default function DateRangePicker() {
   const [open, setOpen] = useState(false)
   const [activePreset, setActivePreset] = useState<string>('All Time')
 
+  // `from` is the start date, `to` is the end date. Leave `to` undefined until
+  // an end date is actually chosen, so the calendar stays in "pick the end
+  // date" mode after the first (start) click.
   const range: DateRange | undefined = activePreset === 'All Time' ? undefined : {
-    from: parseISO(endDate),
-    to: parseISO(startDate),
+    from: parseISO(startDate),
+    to: endDate ? parseISO(endDate) : undefined,
   }
 
   const handlePreset = (preset: typeof PRESETS[number]) => {
     setActivePreset(preset.label)
     const dates = preset.get()
     if (dates) {
-      setGlobalEndDate(dates.from.toISOString())
-      setGlobalStartDate(dates.to.toISOString())
+      setGlobalStartDate(dates.from.toISOString())
+      setGlobalEndDate(dates.to.toISOString())
     }
     if (preset.label === 'All Time') setOpen(false)
   }
 
+  // First click sets the start date; second click sets the end date.
   const handleSelect = (selected: DateRange | undefined) => {
-    if (!selected) return
+    if (!selected?.from) return
     setActivePreset('')
-    if (selected.from) setGlobalEndDate(selected.from.toISOString())
-    if (selected.to) {
-      setGlobalStartDate(selected.to.toISOString())
-      setOpen(false)
-    }
+    setGlobalStartDate(selected.from.toISOString())
+    setGlobalEndDate(selected.to ? selected.to.toISOString() : '')
+    if (selected.to) setOpen(false)
   }
 
   const label = activePreset
     ? activePreset
-    : range?.from && range?.to
-      ? `${format(range.from, 'MMM d, yyyy')} – ${format(range.to, 'MMM d, yyyy')}`
+    : range?.from
+      ? range.to
+        ? `${format(range.from, 'MMM d, yyyy')} – ${format(range.to, 'MMM d, yyyy')}`
+        : format(range.from, 'MMM d, yyyy')
       : 'Select range'
 
   // TODO: enable once API supports date filtering on getProjectKPIs endpoint

--- a/apps/web/src/component/header/InterventionDateRangePicker.tsx
+++ b/apps/web/src/component/header/InterventionDateRangePicker.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { CalendarIcon, X } from 'lucide-react'
-import { format, parseISO, startOfDay, endOfDay, startOfWeek, endOfWeek, startOfMonth, endOfMonth, startOfYear, endOfYear } from 'date-fns'
+import { format, parseISO, startOfDay, endOfDay, startOfWeek, endOfWeek, startOfMonth, endOfMonth, startOfYear, endOfYear, startOfQuarter, endOfQuarter, subQuarters, subYears } from 'date-fns'
 import type { DateRange } from 'react-day-picker'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Calendar } from '@/components/ui/calendar'
@@ -16,6 +16,8 @@ const PRESETS = [
   { label: 'This Week',  get: () => ({ from: startOfWeek(new Date()), to: endOfWeek(new Date()) }) },
   { label: 'This Month', get: () => ({ from: startOfMonth(new Date()), to: endOfMonth(new Date()) }) },
   { label: 'This Year',  get: () => ({ from: startOfYear(new Date()), to: endOfYear(new Date()) }) },
+  { label: 'Last Quarter', get: () => ({ from: startOfQuarter(subQuarters(new Date(), 1)), to: endOfQuarter(subQuarters(new Date(), 1)) }) },
+  { label: 'Last Year',  get: () => ({ from: startOfYear(subYears(new Date(), 1)), to: endOfYear(subYears(new Date(), 1)) }) },
 ] as const
 
 const toKey = (d: Date) => format(d, 'yyyy-MM-dd')
@@ -24,43 +26,67 @@ export default function InterventionDateRangePicker() {
   const { startDate, endDate, setDateRange, resetDateRange } = useInterventionFilterStore()
   const [open, setOpen] = useState(false)
 
-  const range: DateRange | undefined = startDate
-    ? { from: parseISO(startDate), to: endDate ? parseISO(endDate) : parseISO(startDate) }
+  // The committed range from the store drives the actual list filter.
+  const committed: DateRange | undefined = startDate
+    ? { from: parseISO(startDate), to: endDate ? parseISO(endDate) : undefined }
     : undefined
+
+  // While the popover is open we hold the in-progress pick locally so the
+  // filter is not applied until the user has chosen a full range.
+  const [draft, setDraft] = useState<DateRange | undefined>(committed)
+  const range = open ? draft : committed
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) setDraft(committed)
+    setOpen(next)
+  }
 
   const handlePreset = (preset: typeof PRESETS[number]) => {
     const dates = preset.get()
     if (dates) {
+      setDraft({ from: dates.from, to: dates.to })
       setDateRange(toKey(dates.from), toKey(dates.to))
     } else {
+      setDraft(undefined)
       resetDateRange()
       setOpen(false)
     }
   }
 
+  // First click sets the start date; second click sets the end date. The filter
+  // is committed only once a full range (a distinct end date) is chosen.
   const handleSelect = (selected: DateRange | undefined) => {
-    if (!selected?.from) return
-    setDateRange(toKey(selected.from), selected.to ? toKey(selected.to) : toKey(selected.from))
-    if (selected.to) setOpen(false)
+    if (!selected?.from) {
+      setDraft(undefined)
+      return
+    }
+    setDraft(selected)
+    const start = toKey(selected.from)
+    const end = selected.to ? toKey(selected.to) : ''
+    if (end && end !== start) {
+      setDateRange(start, end)
+      setOpen(false)
+    }
   }
 
-  const label = range?.from
-    ? range.to && toKey(range.from) !== toKey(range.to)
-      ? `${format(range.from, 'MMM d, yyyy')} - ${format(range.to, 'MMM d, yyyy')}`
-      : format(range.from, 'MMM d, yyyy')
+  // The trigger reflects the committed (applied) filter, not the in-progress pick.
+  const label = committed?.from
+    ? committed.to && toKey(committed.from) !== toKey(committed.to)
+      ? `${format(committed.from, 'MMM d, yyyy')} - ${format(committed.to, 'MMM d, yyyy')}`
+      : format(committed.from, 'MMM d, yyyy')
     : 'All Time'
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm" className="h-8 gap-1.5 text-xs font-normal">
           <CalendarIcon size={14} />
           {label}
-          {range?.from && (
+          {committed?.from && (
             <span
               role="button"
               tabIndex={0}
-              onClick={(e) => { e.stopPropagation(); resetDateRange() }}
+              onClick={(e) => { e.stopPropagation(); setDraft(undefined); resetDateRange() }}
               className="ml-0.5 rounded-sm hover:bg-muted"
             >
               <X size={12} />


### PR DESCRIPTION
- Hold in-progress pick in local draft; apply intervention filter only once a full range is chosen (no premature refetch on first click)
- Keep popover open after the start date until a distinct end date is set
- Fix reversed start/end mapping in analytics DateRangePicker
- Add Last Quarter and Last Year presets to both pickers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Last Quarter" and "Last Year" presets to date range filters for faster access to common time periods.
  * Improved date range picker with clearer separation between draft selections and confirmed dates.
  * Enhanced popover interactions to better manage when selections are finalized and applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Plant-for-the-Planet-org/treemapper/pull/1031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->