### PR TITLE
Fix/intervention page

### DIFF
--- a/apps/web/src/app/(dashboard)/project/[projectUid]/intervention/component/InterventionCard.tsx
+++ b/apps/web/src/app/(dashboard)/project/[projectUid]/intervention/component/InterventionCard.tsx
@@ -11,10 +11,10 @@ import {
   Activity,
   Target,
   AlertTriangle,
-  FileText,
+  CloudAlert,
+  CloudCheck,
 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { FlagTooltip } from './FlagTooltip';
 import { LucideIcon } from 'lucide-react';
@@ -50,6 +50,7 @@ interface Intervention {
   uid: string;
   hid: string;
   type: string;
+  // capture completeness: 'complete' | 'partial' | 'incomplete'
   captureStatus: string;
   registrationDate: string;
   flag?: boolean;
@@ -71,15 +72,10 @@ interface InterventionCardProps {
   disabledTooltip?: string;
 }
 
-const CAPTURE_STATUS: Record<string, string> = {
-  complete: 'bg-primary/10 text-primary border-primary/20',
-  partial: 'bg-amber-50 text-amber-700 border-amber-200',
-  incomplete: 'bg-destructive/10 text-destructive border-destructive/20',
-};
 
 const formatDate = (d: string) => {
   if (!d) return 'N/A';
-  return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return new Date(d).toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
 };
 
 export const InterventionCard = ({
@@ -87,6 +83,20 @@ export const InterventionCard = ({
 }: InterventionCardProps) => {
   const IconComponent = interventionTypeIcons[intervention.type] || Target;
   const selected = (isSelected && !isMultiSelectMode) || isChecked;
+
+  // NOTE (i18n): the number formatting ('en-US'), the "Tree" / "Trees"
+  // pluralization, the title-casing of the type name and the date format are
+  // all English-only. When the app adds multiple languages, move these to the
+  // shared translation/locale layer (locale-aware number + plural rules).
+  //
+  // For tree-registration interventions the type name adds little; the tree
+  // count is the meaningful headline (e.g. "1 Tree" / "240 Trees").
+  const isTreeRegistration =
+    intervention.type === 'single-tree-registration' ||
+    intervention.type === 'multi-tree-registration';
+  const title = isTreeRegistration
+    ? `${intervention.treeCount.toLocaleString('en-US')} ${intervention.treeCount === 1 ? 'Tree' : 'Trees'}`
+    : intervention.type.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
 
   return (
     <Card
@@ -122,42 +132,37 @@ export const InterventionCard = ({
           )}>
             <IconComponent className="h-4 w-4" />
             {intervention.flag && (
-              <FlagTooltip flagReasons={intervention.flagReason}>
-                <div className="absolute -top-1 -right-1 w-3 h-3 bg-destructive rounded-full flex items-center justify-center">
-                  <AlertTriangle className="w-2 h-2 text-white" />
-                </div>
-              </FlagTooltip>
+              <div className="absolute -top-1 -right-1">
+                <FlagTooltip flagReasons={intervention.flagReason}>
+                  <div className="w-3 h-3 bg-destructive rounded-full flex items-center justify-center">
+                    <AlertTriangle className="w-2 h-2 text-white" />
+                  </div>
+                </FlagTooltip>
+              </div>
             )}
           </div>
 
           <div className="flex-1 min-w-0">
-            <div className="flex items-start justify-between mb-2 gap-2">
-              <h3 className="font-medium text-foreground text-sm leading-snug break-words">
-                {intervention.type.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}
-              </h3>
-              <Badge
-                variant="outline"
-                className={cn('text-xs flex-shrink-0', CAPTURE_STATUS[intervention.captureStatus])}
-              >
-                {intervention.captureStatus}
-              </Badge>
-            </div>
-
-            <div className="space-y-2 text-xs text-muted-foreground">
-              <div className="flex items-center gap-1.5">
-                <Calendar className="h-3 w-3 text-muted-foreground/60" />
-                <span>{formatDate(intervention.registrationDate)}</span>
-              </div>
-
-              <div className="flex items-center justify-between">
-                <span className="font-mono bg-muted px-2 py-0.5 rounded text-foreground/80">
+            {/* Header: title + HID (left) | status cloud and records (right) */}
+            <div className="flex items-start justify-between mb-1.5 gap-2">
+              <div className="flex items-center gap-1.5 min-w-0">
+                <h3 className="font-medium text-foreground text-sm leading-snug truncate">
+                  {title}
+                </h3>
+                <span className="font-mono text-[11px] bg-muted px-1.5 py-0.5 rounded text-foreground/80 flex-shrink-0">
                   {intervention.hid}
                 </span>
-                {intervention.hasRecords && (
-                  <FileText className="h-3 w-3 text-primary" aria-label="Has Records" />
+              </div>
+              <div className="flex items-center gap-1.5 flex-shrink-0">
+                {intervention.captureStatus === 'complete' ? (
+                  <CloudCheck className="h-3.5 w-3.5 text-primary" aria-label="Synced" />
+                ) : (
+                  <CloudAlert className="h-3.5 w-3.5 text-amber-600" aria-label="Not synced" />
                 )}
               </div>
+            </div>
 
+            <div className="space-y-1.5 text-xs text-muted-foreground">
               {intervention.site && (
                 <div className="flex items-center gap-1.5">
                   <MapPin className="h-3 w-3 text-muted-foreground/60" />
@@ -165,12 +170,19 @@ export const InterventionCard = ({
                 </div>
               )}
 
-              <div className="flex items-center justify-between">
+              {/* Combined meta line: date, trees, species */}
+              <div className="flex items-center gap-x-3 gap-y-1 flex-wrap">
                 <span className="flex items-center gap-1">
-                  <Trees className="h-3 w-3" />
-                  <span className="font-medium text-foreground/80">{intervention.treeCount}</span>
-                  <span>trees</span>
+                  <Calendar className="h-3 w-3 text-muted-foreground/60" />
+                  <span>{formatDate(intervention.registrationDate)}</span>
                 </span>
+                {!isTreeRegistration && (
+                  <span className="flex items-center gap-1">
+                    <Trees className="h-3 w-3" />
+                    <span className="font-medium text-foreground/80">{intervention.treeCount.toLocaleString('en-US')}</span>
+                    <span>trees</span>
+                  </span>
+                )}
                 {intervention.species && intervention.species.length > 0 && (
                   <span className="flex items-center gap-1">
                     <Leaf className="h-3 w-3" />

--- a/apps/web/src/app/(dashboard)/project/[projectUid]/intervention/component/InterventionDetails.tsx
+++ b/apps/web/src/app/(dashboard)/project/[projectUid]/intervention/component/InterventionDetails.tsx
@@ -8,12 +8,14 @@ import {
   Calendar as CalendarIcon,
   TreePine,
   AlertTriangle,
-  FileText,
   Database,
   Trash2,
   Settings,
   User,
-  Pen
+  Pen,
+  CloudAlert,
+  CloudCheck,
+  MapPin
 } from 'lucide-react';
 import { toast } from 'react-toastify';
 import { deleteIntervention, editIntervention } from '@shared-core/fetchApi/api.fetch';
@@ -22,7 +24,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Dialog, DialogHeader, DialogContent, DialogTitle } from './ui/Dialog';
-import { EditableField, NonEditableField } from './EditableField';
+import { EditableField } from './EditableField';
 import { FileUploadDialog, FileUploadMapDialog } from './FileUploadDialog';
 import { FlagTooltip } from './FlagTooltip';
 import { TreeCard } from './TreeCard';
@@ -92,7 +94,8 @@ interface Intervention {
   hid: string;
   type: string;
   captureStatus: string;
-  interventionStatus: string;
+  // lifecycle status from the API ('planned' | 'active' | 'completed' | ...)
+  status?: string;
   registrationDate: string;
   interventionStartDate?: string;
   interventionEndDate?: string;
@@ -137,6 +140,39 @@ interface InterventionDetailsProps {
   onBack?: () => void;
 }
 
+// Reusable collapsible card section (Species / Sample Trees / Technical).
+const CollapsibleSection = ({
+  icon: Icon, title, count, open, onToggle, children,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  count?: number;
+  open: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) => (
+  <Card>
+    <CardHeader>
+      <button onClick={onToggle} className="flex items-center justify-between w-full text-left group">
+        <h3 className="font-medium text-foreground flex items-center gap-2">
+          <Icon className="h-3.5 w-3.5 text-primary" />
+          {title}{typeof count === 'number' ? ` (${count})` : ''}
+        </h3>
+        <ChevronDown className={cn('h-4 w-4 text-muted-foreground transition-transform group-hover:text-foreground', open && 'rotate-180')} />
+      </button>
+    </CardHeader>
+    {open && <CardContent>{children}</CardContent>}
+  </Card>
+);
+
+// One label/value row in the Technical details list.
+const DetailRow = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="flex justify-between gap-2">
+    <span className="text-muted-foreground">{label}</span>
+    <span className="font-medium text-foreground text-right">{children}</span>
+  </div>
+);
+
 export const InterventionDetails = ({
   intervention,
   onUpdate,
@@ -167,7 +203,7 @@ export const InterventionDetails = ({
     setLocalSpecies(intervention.species || []);
   }, [intervention.species]);
 
-  const canEditSpecies =
+  const canManage =
     selectedProjectDetails.userRole === 'owner' || selectedProjectDetails.userRole === 'admin';
 
   const handleSpeciesSaveComplete = (updated: Species) => {
@@ -183,14 +219,12 @@ export const InterventionDetails = ({
   };
 
   const handleFieldUpdate = async (field: string, value: unknown) => {
-    console.log(`Updating intervention ${field} to:`, value, intervention);
-    const resp = await editIntervention(accessToken, {
+    await editIntervention(accessToken, {
       interventionUid: intervention.uid,
       prjid: selectedProject,
       field,
       value
     });
-    console.log('Edit response:', resp);
     await onUpdate?.(intervention.uid, { [field]: value });
   };
 
@@ -222,11 +256,6 @@ export const InterventionDetails = ({
     setShowDeleteDialog(false);
   };
 
-  const formatDate = (dateString?: string) => {
-    if (!dateString) return '';
-    return new Date(dateString).toISOString().split('T')[0];
-  };
-
   const displayDate = (dateString?: string) => {
     if (!dateString) return 'Not set';
     return new Date(dateString).toLocaleDateString('en-US', {
@@ -236,8 +265,15 @@ export const InterventionDetails = ({
     });
   };
 
+  // Start/end shown as one date range (display only; edit via the Edit modal).
+  const rangeLabel = intervention.interventionStartDate
+    ? intervention.interventionEndDate
+      ? `${displayDate(intervention.interventionStartDate)} – ${displayDate(intervention.interventionEndDate)}`
+      : displayDate(intervention.interventionStartDate)
+    : 'Not set';
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 @container">
       {onBack && (
         <button
           onClick={onBack}
@@ -251,7 +287,7 @@ export const InterventionDetails = ({
       <Card className="py-0 gap-0">
         <CardContent className="p-0">
           <div className="h-64 flex items-center justify-center overflow-hidden">
-            <MapDisplayComponent geoJSON={intervention.originalGeometry} />
+            <MapDisplayComponent geoJSON={intervention.originalGeometry} trees={intervention.trees} />
           </div>
         </CardContent>
       </Card>
@@ -259,7 +295,7 @@ export const InterventionDetails = ({
       {/* Header Card */}
       <Card>
         <CardHeader>
-          <div className="flex items-start justify-between">
+          <div className="flex flex-col gap-3 @lg:flex-row @lg:items-start @lg:justify-between">
             <div className="flex-1">
               <div className="flex items-center gap-3 mb-2">
                 <h2 className="text-xl font-semibold text-foreground">
@@ -273,59 +309,60 @@ export const InterventionDetails = ({
                     </Badge>
                   </FlagTooltip>
                 )}
-                {intervention.hasRecords && (
-                  <Badge variant="outline">
-                    <FileText className="h-3 w-3 mr-1" />
-                    Has Records
-                  </Badge>
-                )}
               </div>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <span>ID: {intervention.hid}</span>
+                <span>HID: {intervention.hid}</span>
                 <span>•</span>
-                <span>Created: {new Date(intervention.createdAt).toLocaleDateString()}</span>
+                <span>Created {displayDate(intervention.createdAt)}</span>
               </div>
             </div>
-            <div className="flex items-center gap-3">
-              <Badge variant={intervention.interventionStatus === 'completed' ? 'default' : 'secondary'} className="capitalize">
-                {intervention.interventionStatus}
-              </Badge>
+            <div className="flex flex-wrap items-center gap-2 @lg:gap-3">
+              {intervention.status && (
+                <Badge variant={intervention.status === 'completed' ? 'default' : 'secondary'} className="capitalize">
+                  {intervention.status.replace(/-/g, ' ')}
+                </Badge>
+              )}
               <Badge
                 variant="outline"
                 className={cn(
-                  'capitalize',
+                  'gap-1',
                   intervention.captureStatus === 'complete'
                     ? 'bg-primary/10 text-primary border-primary/20'
                     : 'bg-amber-50 text-amber-700 border-amber-200'
                 )}
               >
-                {intervention.captureStatus}
+                {intervention.captureStatus === 'complete' ? (
+                  <><CloudCheck className="h-3 w-3" /> Synced</>
+                ) : (
+                  <><CloudAlert className="h-3 w-3" /> Not synced</>
+                )}
               </Badge>
-              {(selectedProjectDetails.userRole === 'owner' || selectedProjectDetails.userRole === 'admin') && (
-                <Button variant="outline" size="sm" onClick={() => setShowEditModal(true)}>
-                  <Pen className="h-4 w-4" />
-                  Edit
-                </Button>
-              )}
-              {(selectedProjectDetails.userRole === 'owner' || selectedProjectDetails.userRole === 'admin') && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => setShowDeleteDialog(true)}
-                  className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
+              {canManage && (
+                <>
+                  <Button variant="ghost" size="sm" onClick={() => setShowEditModal(true)}>
+                    <Pen className="h-4 w-4" />
+                    Edit
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowDeleteDialog(true)}
+                    className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    Delete
+                  </Button>
+                </>
               )}
             </div>
           </div>
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* Key metrics — inline */}
+          {/* Key metrics — each shown once */}
           <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm border-t border-border pt-4">
             <span className="flex items-center gap-1.5">
               <Trees className="h-4 w-4 text-muted-foreground" />
-              <span className="font-semibold text-foreground">{intervention.treeCount}</span>
+              <span className="font-semibold text-foreground">{intervention.treeCount.toLocaleString('en-US')}</span>
               <span className="text-muted-foreground">Trees</span>
             </span>
             <span className="flex items-center gap-1.5">
@@ -336,44 +373,29 @@ export const InterventionDetails = ({
             {intervention.type !== 'single-tree-registration' && (
               <span className="flex items-center gap-1.5">
                 <TreePine className="h-4 w-4 text-muted-foreground" />
-                <span className="font-semibold text-foreground">{intervention.trees?.length || 0}</span>
+                <span className="font-semibold text-foreground">{(intervention.trees?.length || 0).toLocaleString('en-US')}</span>
                 <span className="text-muted-foreground">Sample Trees</span>
               </span>
             )}
-            <span className="flex items-center gap-1.5">
-              <CalendarIcon className="h-4 w-4 text-muted-foreground" />
-              <span className="text-muted-foreground">Updated</span>
-              <span className="font-semibold text-foreground">{new Date(intervention.updatedAt).toLocaleDateString()}</span>
-            </span>
           </div>
 
-            {/* Editable Fields Grid */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <div className="space-y-4">
-                <EditableField
-                  label="Start Date"
-                  value={formatDate(intervention.interventionStartDate)}
-                  displayValue={displayDate(intervention.interventionStartDate)}
-                  type="date"
-                  onSave={(value) => handleFieldUpdate('interventionStartDate', value)}
-                />
-
-                <NonEditableField
-                  label="Tree Count"
-                  value={intervention.treeCount?.toString() || '0'}
-                  type="number"
-                  onSave={(value) => handleFieldUpdate('treeCount', parseInt(value))}
-                />
+            {/* Dates and site */}
+            <div className="grid grid-cols-1 @lg:grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-muted-foreground">Dates</label>
+                <div className="flex items-center gap-2 text-sm">
+                  <CalendarIcon className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                  <span className={cn(!intervention.interventionStartDate && 'text-muted-foreground')}>{rangeLabel}</span>
+                </div>
               </div>
-
-              <div className="space-y-4">
-                <EditableField
-                  label="End Date"
-                  value={formatDate(intervention.interventionEndDate)}
-                  displayValue={displayDate(intervention.interventionEndDate)}
-                  type="date"
-                  onSave={(value) => handleFieldUpdate('interventionEndDate', value)}
-                />
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-muted-foreground">Site</label>
+                <div className="flex items-center gap-2 text-sm">
+                  <MapPin className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                  <span className={cn('truncate', !intervention.site && 'text-muted-foreground')}>
+                    {intervention.site?.name || 'Not assigned'}
+                  </span>
+                </div>
               </div>
             </div>
 
@@ -389,165 +411,87 @@ export const InterventionDetails = ({
 
       {/* Species Section */}
       {localSpecies.length > 0 && (
-        <Card>
-          <CardHeader>
-            <button
-              onClick={() => toggleSection('species')}
-              className="flex items-center justify-between w-full text-left group"
-            >
-              <h3 className="font-medium text-foreground flex items-center gap-2">
-                <Leaf className="h-3.5 w-3.5 text-primary" />
-                Species Planted ({localSpecies.length})
-              </h3>
-              <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform group-hover:text-foreground ${expandedSections.species ? 'rotate-180' : ''
-                }`} />
-            </button>
-          </CardHeader>
-
-          {expandedSections.species && (
-            <CardContent>
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                {localSpecies.map((sp, index) => (
-                  <SpeciesCard
-                    key={sp.uid || index}
-                    species={sp}
-                    setEditSpecies={(s) => setEditSpecies(s as Species)}
-                    canEdit={canEditSpecies}
-                  />
-                ))}
-              </div>
-            </CardContent>
-          )}
-        </Card>
+        <CollapsibleSection
+          icon={Leaf}
+          title="Species Planted"
+          count={localSpecies.length}
+          open={expandedSections.species}
+          onToggle={() => toggleSection('species')}
+        >
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {localSpecies.map((sp, index) => (
+              <SpeciesCard
+                key={sp.uid || index}
+                species={sp}
+                setEditSpecies={(s) => setEditSpecies(s as Species)}
+                canEdit={canManage}
+              />
+            ))}
+          </div>
+        </CollapsibleSection>
       )}
 
-      {/* Trees Section */}
+      {/* Sample Trees Section */}
       {intervention.trees && intervention.trees.length > 0 && (
-        <Card>
-          <CardHeader>
-            <button
-              onClick={() => toggleSection('trees')}
-              className="flex items-center justify-between w-full text-left group"
-            >
-              <h3 className="font-medium text-foreground flex items-center gap-2">
-                <Trees className="h-3.5 w-3.5 text-primary" />
-                Sample Trees ({intervention.trees.length})
-              </h3>
-              <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform group-hover:text-foreground ${expandedSections.trees ? 'rotate-180' : ''
-                }`} />
-            </button>
-          </CardHeader>
-
-          {expandedSections.trees && (
-            <CardContent>
-              <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
-                {intervention.trees.map((tree) => (
-                  <TreeCard
-                    key={tree.id}
-                    tree={tree}
-                    intervention={intervention}
-                    accessToken={accessToken}
-                    selectedProject={selectedProject}
-                    onUpdate={(treeHid, updates) => {
-                      console.log(`Updating tree ${treeHid}:`, updates);
-                      onUpdate?.(intervention.uid, {});
-                    }}
-                  />
-                ))}
-              </div>
-            </CardContent>
-          )}
-        </Card>
+        <CollapsibleSection
+          icon={Trees}
+          title="Sample Trees"
+          count={intervention.trees.length}
+          open={expandedSections.trees}
+          onToggle={() => toggleSection('trees')}
+        >
+          <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+            {intervention.trees.map((tree) => (
+              <TreeCard
+                key={tree.id}
+                tree={tree}
+                intervention={intervention}
+                accessToken={accessToken}
+                selectedProject={selectedProject}
+                onUpdate={() => onUpdate?.(intervention.uid, {})}
+              />
+            ))}
+          </div>
+        </CollapsibleSection>
       )}
 
-      {/* Metadata Section */}
-      <Card>
-        <CardHeader>
-          <button
-            onClick={() => toggleSection('metadata')}
-            className="flex items-center justify-between w-full text-left group"
-          >
-            <h3 className="font-medium text-foreground flex items-center gap-2">
-              <Database className="h-3.5 w-3.5 text-primary" />
-              Technical Details
-            </h3>
-            <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform group-hover:text-foreground ${expandedSections.metadata ? 'rotate-180' : ''
-              }`} />
-          </button>
-        </CardHeader>
-
-        {expandedSections.metadata && (
-          <CardContent>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 text-sm">
-              <div className="space-y-3">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Registration Date:</span>
-                  <span className="font-medium text-foreground">{displayDate(intervention.registrationDate)}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Capture Mode:</span>
-                  <span className="font-medium text-foreground capitalize">{intervention.captureMode?.replace('-', ' ')}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Sample Tree Count:</span>
-                  <span className="font-medium text-foreground">{intervention.sampleTreeCount}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Privacy:</span>
-                  <span className="font-medium text-foreground">{intervention.isPrivate ? 'Private' : 'Public'}</span>
-                </div>
-              </div>
-
-              <div className="space-y-3">
-                {intervention.site && (
-                  <>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Site:</span>
-                      <span className="font-medium text-foreground">{intervention.site.name}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Site Status:</span>
-                      <span className="font-medium text-foreground capitalize">{intervention.site.status}</span>
-                    </div>
-                  </>
+      {/* Technical Details */}
+      <CollapsibleSection
+        icon={Database}
+        title="Technical Details"
+        open={expandedSections.metadata}
+        onToggle={() => toggleSection('metadata')}
+      >
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+          <DetailRow label="Registration date">{displayDate(intervention.registrationDate)}</DetailRow>
+          <DetailRow label="Capture mode"><span className="capitalize">{intervention.captureMode?.replace('-', ' ') || 'Unknown'}</span></DetailRow>
+          <DetailRow label="Privacy">{intervention.isPrivate ? 'Private' : 'Public'}</DetailRow>
+          <DetailRow label="Added by">
+            <span className="flex items-center gap-1.5 min-w-0">
+              <span className="w-5 h-5 bg-muted rounded-full flex items-center justify-center overflow-hidden flex-shrink-0">
+                {intervention.user?.image ? (
+                  <img src={intervention.user.image} className="h-full w-full rounded-full" referrerPolicy="no-referrer" />
+                ) : (
+                  <User className="h-3 w-3 text-muted-foreground" />
                 )}
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-muted-foreground">Added by:</span>
-                  <span className="flex items-center gap-1.5 font-medium text-foreground min-w-0">
-                    <span className="w-5 h-5 bg-muted rounded-full flex items-center justify-center overflow-hidden flex-shrink-0">
-                      {intervention.user?.image ? (
-                        <img src={intervention.user.image} className="h-full w-full rounded-full" referrerPolicy="no-referrer" />
-                      ) : (
-                        <User className="h-3 w-3 text-muted-foreground" />
-                      )}
-                    </span>
-                    <span className="truncate">{intervention.user?.name || 'Unknown'}</span>
-                  </span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Created:</span>
-                  <span className="font-medium text-foreground">{displayDate(intervention.createdAt)}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Last Updated:</span>
-                  <span className="font-medium text-foreground">{displayDate(intervention.updatedAt)}</span>
-                </div>
-              </div>
-            </div>
+              </span>
+              <span className="truncate">{intervention.user?.name || 'Unknown'}</span>
+            </span>
+          </DetailRow>
+          <DetailRow label="Last updated">{displayDate(intervention.updatedAt)}</DetailRow>
+        </div>
 
-            {intervention.metadata && (
-              <div className="mt-6 pt-6 border-t border-border">
-                <h4 className="font-medium text-foreground mb-3">Raw Metadata</h4>
-                <div className="bg-muted/40 rounded-lg p-4 max-h-60 overflow-y-auto">
-                  <pre className="text-xs text-muted-foreground whitespace-pre-wrap">
-                    {JSON.stringify(intervention.metadata, null, 2)}
-                  </pre>
-                </div>
-              </div>
-            )}
-          </CardContent>
+        {intervention.metadata && (
+          <div className="mt-6 pt-6 border-t border-border">
+            <h4 className="font-medium text-foreground mb-3">Raw Metadata</h4>
+            <div className="bg-muted/40 rounded-lg p-4 max-h-60 overflow-y-auto">
+              <pre className="text-xs text-muted-foreground whitespace-pre-wrap">
+                {JSON.stringify(intervention.metadata, null, 2)}
+              </pre>
+            </div>
+          </div>
         )}
-      </Card>
+      </CollapsibleSection>
 
       {/* Modals */}
       <EditSpeciesModal

--- a/apps/web/src/app/(dashboard)/project/[projectUid]/intervention/component/InterventionDisplayMap.tsx
+++ b/apps/web/src/app/(dashboard)/project/[projectUid]/intervention/component/InterventionDisplayMap.tsx
@@ -5,15 +5,29 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 
 interface Props {
   geoJSON: any; // GeoJSON data or geometry from parent
+  trees?: any[]; // sample trees to plot as points
 }
 
-const MapDisplayComponent = ({ geoJSON }: Props) => {
-  const mapRef = useRef();
+// Extract [lng, lat] from a tree, supporting a Point geometry or lat/lng fields.
+const treeCoords = (tree: any): [number, number] | null => {
+  const loc = tree?.location;
+  if (loc?.type === 'Point' && Array.isArray(loc.coordinates) && loc.coordinates.length === 2) {
+    return [loc.coordinates[0], loc.coordinates[1]];
+  }
+  if (Array.isArray(loc) && loc.length === 2 && typeof loc[0] === 'number') {
+    return [loc[0], loc[1]];
+  }
+  if (typeof tree?.longitude === 'number' && typeof tree?.latitude === 'number') {
+    return [tree.longitude, tree.latitude];
+  }
+  return null;
+};
+
+const MapDisplayComponent = ({ geoJSON, trees = [] }: Props) => {
+  const mapRef = useRef<any>(null);
   const [error, setError] = useState(null);
   const [processedGeoJSON, setProcessedGeoJSON] = useState(null);
   const [showInfo, setShowInfo] = useState(false);
-  
-  console.log("Raw geoJSON prop:", geoJSON);
 
   // Initial viewport settings
   const [viewState, setViewState] = useState({
@@ -165,19 +179,15 @@ const MapDisplayComponent = ({ geoJSON }: Props) => {
 
   // Effect to handle geoJSON changes and validation
   useEffect(() => {
-    console.log("Processing geoJSON update:", geoJSON);
-    
     const { error: validationError, geoJSON: validatedGeoJSON } = validateAndNormalizeGeoJSON(geoJSON);
-    
+
     if (validationError) {
       setError(validationError);
       setProcessedGeoJSON(null);
-      console.error("GeoJSON validation error:", validationError);
     } else {
       setError(null);
       setProcessedGeoJSON(validatedGeoJSON);
-      console.log("Processed GeoJSON:", validatedGeoJSON);
-      
+
       // Calculate bounds and fit map
       if (validatedGeoJSON) {
         const bounds = calculateBounds(validatedGeoJSON);
@@ -313,11 +323,25 @@ const MapDisplayComponent = ({ geoJSON }: Props) => {
           <>
             {/* Render point markers */}
             {processedGeoJSON.geometry.type === 'Point' && renderPointMarker(processedGeoJSON.geometry.coordinates)}
-            
+
             {/* Render polygon/line layers */}
             {renderGeometryLayers()}
           </>
         )}
+
+        {/* Sample tree markers */}
+        {trees.map((tree) => {
+          const coords = treeCoords(tree);
+          if (!coords) return null;
+          return (
+            <Marker key={`tree-${tree.id ?? tree.hid}`} longitude={coords[0]} latitude={coords[1]} anchor="center">
+              <div
+                title={tree.hid}
+                className="w-2.5 h-2.5 rounded-full bg-[#007A49] border border-white shadow-sm"
+              />
+            </Marker>
+          );
+        })}
       </Map>
 
       {/* Info toggle button */}

--- a/apps/web/src/app/(dashboard)/project/[projectUid]/intervention/component/InterventionsPanel.tsx
+++ b/apps/web/src/app/(dashboard)/project/[projectUid]/intervention/component/InterventionsPanel.tsx
@@ -1,11 +1,14 @@
 'use client'
 
 import React from 'react'
-import { Search, ArrowUp, ArrowDown, CheckSquare, X, Trees, Loader } from 'lucide-react'
+import { Search, ArrowUp, ArrowDown, CheckSquare, X, Trees, Loader, ListFilter, Flag, FlagOff, MapPin, Leaf, Calendar } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
 import { InterventionCard } from './InterventionCard'
 
 interface Site {
@@ -44,9 +47,11 @@ interface Props {
   // bulk
   isBulkMode: boolean
   selectedUids: Set<string>
-  onToggleSelect: (uid: string) => void
+  onToggleSelect: (uid: string, shiftKey?: boolean) => void
   onEnterBulkMode: () => void
   onExitBulkMode: () => void
+  onSelectAll: () => void
+  onClearSelection: () => void
   onOpenBulkUpdate: () => void
   onOpenBulkSpeciesEdit: () => void
   onOpenBulkStartDateEdit: () => void
@@ -55,94 +60,179 @@ interface Props {
 
 const labelize = (s: string) => s.replace(/-/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
 
+const CAPTURE_MODES = [
+  { value: 'on-site', label: 'On Site' },
+  { value: 'off-site', label: 'Off Site' },
+  { value: 'external', label: 'External' },
+  { value: 'unknown', label: 'Unknown' },
+]
+
 export const InterventionsPanel = ({
   interventions, selectedIntervention, onSelect, loading, error,
   searchTerm, setSearchTerm, filters, setFilters, interventionTypes, sites,
   pagination, activeFilterCount, clearAllFilters, hasMore, observerRef, fetchInterventionData, onCreate,
   isBulkMode, selectedUids, onToggleSelect, onEnterBulkMode, onExitBulkMode,
+  onSelectAll, onClearSelection,
   onOpenBulkUpdate, onOpenBulkSpeciesEdit, onOpenBulkStartDateEdit, lockedType,
 }: Props) => {
+  const [filterOpen, setFilterOpen] = React.useState(false)
+  const listRef = React.useRef<HTMLDivElement>(null)
+
+  // Keep the keyboard-selected card visible as the user arrows through.
+  React.useEffect(() => {
+    if (isBulkMode || !selectedIntervention) return
+    const el = listRef.current?.querySelector(`[data-uid="${selectedIntervention.uid}"]`) as HTMLElement | null
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIntervention?.uid, isBulkMode])
+
   const setFilter = (key: string, value: string) =>
     setFilters((prev: any) => ({ ...prev, [key]: value === 'all' ? '' : value }))
 
   const toggleSort = () =>
     setFilters((prev: any) => ({ ...prev, sortOrder: prev.sortOrder === 'asc' ? 'desc' : 'asc' }))
 
+  // Flag is an independent toggle (sits next to sort) that cycles:
+  // all -> flagged only -> not flagged -> all.
+  const FLAG_CYCLE = ['all', 'true', 'false']
+  const cycleFlag = () => {
+    const cur = filters.flag || 'all'
+    setFilter('flag', FLAG_CYCLE[(FLAG_CYCLE.indexOf(cur) + 1) % FLAG_CYCLE.length])
+  }
+  const flagTitle = filters.flag === 'true' ? 'Showing flagged only'
+    : filters.flag === 'false' ? 'Showing not flagged'
+    : 'Flag: all'
+
+  const siteName = (id: string) => sites.find((s) => String(s.id) === id)?.name ?? id
+
+  // Active popover filters shown as removable chips under the search bar.
+  // Flag is excluded: it has its own independent toggle next to sort.
+  const activeChips = [
+    filters.type && { key: 'type', label: `Type: ${labelize(filters.type)}` },
+    filters.projectSiteId && { key: 'projectSiteId', label: `Site: ${siteName(filters.projectSiteId)}` },
+    filters.captureMode && { key: 'captureMode', label: `Mode: ${CAPTURE_MODES.find((m) => m.value === filters.captureMode)?.label ?? filters.captureMode}` },
+  ].filter(Boolean) as { key: string; label: string }[]
+
+  const total = Number(pagination.total) || interventions.length
+
+  // Bulk select: items eligible to (de)select together share one type.
+  const eligibleType = lockedType ?? interventions[0]?.type
+  const eligibleUids = interventions.filter((i) => i.type === eligibleType).map((i) => i.uid)
+  const allEligibleSelected = eligibleUids.length > 0 && eligibleUids.every((uid) => selectedUids.has(uid))
+
   return (
     <div className="w-full h-full flex flex-col bg-background border-r border-border/50">
       {/* Filters */}
       <div className="p-3 space-y-2 border-b border-border/50 flex-shrink-0">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/60" size={14} />
-          <Input
-            placeholder="Search by HID..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="pl-8 h-8 text-xs"
-          />
-        </div>
-
-        <div className="grid grid-cols-2 gap-2">
-          <Select value={filters.type || 'all'} onValueChange={(v) => setFilter('type', v)}>
-            <SelectTrigger size="sm" className="h-8 text-xs">
-              <SelectValue placeholder="All Types" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all" className="text-xs">All Types</SelectItem>
-              {interventionTypes.map((t) => (
-                <SelectItem key={t} value={t} className="text-xs">{labelize(t)}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          <Select value={filters.projectSiteId || 'all'} onValueChange={(v) => setFilter('projectSiteId', v)}>
-            <SelectTrigger size="sm" className="h-8 text-xs">
-              <SelectValue placeholder="All Sites" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all" className="text-xs">All Sites</SelectItem>
-              {sites.map((s) => (
-                <SelectItem key={s.id} value={String(s.id)} className="text-xs">{s.name}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          <Select value={filters.captureMode || 'all'} onValueChange={(v) => setFilter('captureMode', v)}>
-            <SelectTrigger size="sm" className="h-8 text-xs">
-              <SelectValue placeholder="All Capture Modes" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all" className="text-xs">All Capture Modes</SelectItem>
-              <SelectItem value="on-site" className="text-xs">On Site</SelectItem>
-              <SelectItem value="off-site" className="text-xs">Off Site</SelectItem>
-              <SelectItem value="external" className="text-xs">External</SelectItem>
-              <SelectItem value="unknown" className="text-xs">Unknown</SelectItem>
-            </SelectContent>
-          </Select>
-
-          <div className="flex items-center gap-2">
-            <Select value={filters.flag || 'all'} onValueChange={(v) => setFilter('flag', v)}>
-              <SelectTrigger size="sm" className="h-8 text-xs flex-1">
-                <SelectValue placeholder="All Items" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all" className="text-xs">All Items</SelectItem>
-                <SelectItem value="true" className="text-xs">Flagged Only</SelectItem>
-                <SelectItem value="false" className="text-xs">Not Flagged</SelectItem>
-              </SelectContent>
-            </Select>
-            <button
-              onClick={toggleSort}
-              title="Sort by date"
-              className="flex items-center gap-0.5 h-8 px-2 rounded-md border border-border bg-background text-muted-foreground hover:bg-muted/50 text-xs transition-colors"
-            >
-              {filters.sortOrder === 'asc' ? <ArrowUp size={14} /> : <ArrowDown size={14} />}
-            </button>
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/60" size={14} />
+            <Input
+              placeholder="Search by HID..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-8 h-8 text-xs"
+            />
           </div>
+
+          <Popover open={filterOpen} onOpenChange={setFilterOpen}>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm" className="h-8 gap-1.5 text-xs font-normal">
+                <ListFilter size={14} />
+                Filter
+                {activeChips.length > 0 && (
+                  <Badge className="h-4 min-w-4 px-1 text-[10px] tabular-nums">{activeChips.length}</Badge>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-64 p-3 space-y-3">
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-muted-foreground">Type</label>
+                <Select value={filters.type || 'all'} onValueChange={(v) => setFilter('type', v)}>
+                  <SelectTrigger size="sm" className="h-8 text-xs w-full"><SelectValue placeholder="All Types" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all" className="text-xs">All Types</SelectItem>
+                    {interventionTypes.map((t) => (
+                      <SelectItem key={t} value={t} className="text-xs">{labelize(t)}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-muted-foreground">Site</label>
+                <Select value={filters.projectSiteId || 'all'} onValueChange={(v) => setFilter('projectSiteId', v)}>
+                  <SelectTrigger size="sm" className="h-8 text-xs w-full"><SelectValue placeholder="All Sites" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all" className="text-xs">All Sites</SelectItem>
+                    {sites.map((s) => (
+                      <SelectItem key={s.id} value={String(s.id)} className="text-xs">{s.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-muted-foreground">Capture mode</label>
+                <Select value={filters.captureMode || 'all'} onValueChange={(v) => setFilter('captureMode', v)}>
+                  <SelectTrigger size="sm" className="h-8 text-xs w-full"><SelectValue placeholder="All Capture Modes" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all" className="text-xs">All Capture Modes</SelectItem>
+                    {CAPTURE_MODES.map((m) => (
+                      <SelectItem key={m.value} value={m.value} className="text-xs">{m.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {activeChips.length > 0 && (
+                <Button variant="ghost" size="sm" className="h-7 w-full text-xs text-muted-foreground" onClick={clearAllFilters}>
+                  Clear all filters
+                </Button>
+              )}
+            </PopoverContent>
+          </Popover>
+
+          <button
+            onClick={cycleFlag}
+            title={flagTitle}
+            aria-label={flagTitle}
+            className={cn(
+              'flex items-center justify-center h-8 w-8 rounded-md border transition-colors flex-shrink-0',
+              filters.flag
+                ? 'border-primary/40 bg-primary/10 text-primary'
+                : 'border-border bg-background text-muted-foreground hover:bg-muted/50'
+            )}
+          >
+            {filters.flag === 'false' ? <FlagOff size={14} /> : <Flag size={14} />}
+          </button>
+
+          <button
+            onClick={toggleSort}
+            title="Sort by date"
+            className="flex items-center justify-center h-8 w-8 rounded-md border border-border bg-background text-muted-foreground hover:bg-muted/50 transition-colors flex-shrink-0"
+          >
+            {filters.sortOrder === 'asc' ? <ArrowUp size={14} /> : <ArrowDown size={14} />}
+          </button>
         </div>
 
-        <div className="flex items-center justify-between text-xs text-muted-foreground pt-1">
-          <span>{pagination.total || interventions.length} intervention{(pagination.total || interventions.length) !== 1 ? 's' : ''}</span>
+        {/* Active filter chips */}
+        {activeChips.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {activeChips.map((chip) => (
+              <button
+                key={chip.key}
+                onClick={() => setFilter(chip.key, 'all')}
+                className="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] text-foreground/80 hover:bg-muted/70 transition-colors"
+              >
+                {chip.label}
+                <X size={11} className="text-muted-foreground" />
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="flex items-center justify-between text-xs text-muted-foreground pt-0.5">
+          <span>{total.toLocaleString('en-US')} intervention{total !== 1 ? 's' : ''}</span>
           <div className="flex items-center gap-2">
             {activeFilterCount > 0 && (
               <button onClick={clearAllFilters} className="text-primary hover:underline">
@@ -150,7 +240,11 @@ export const InterventionsPanel = ({
               </button>
             )}
             {!isBulkMode && interventions.length > 0 && (
-              <button onClick={onEnterBulkMode} className="text-primary hover:underline font-medium">
+              <button
+                onClick={onEnterBulkMode}
+                className="flex items-center gap-1 text-muted-foreground hover:text-foreground font-medium transition-colors"
+              >
+                <CheckSquare size={13} />
                 Select
               </button>
             )}
@@ -160,16 +254,35 @@ export const InterventionsPanel = ({
 
       {/* Bulk action bar */}
       {isBulkMode && (
-        <div className="px-3 py-2 bg-primary flex items-center justify-between gap-2 flex-shrink-0">
-          <div className="flex items-center gap-1.5 text-primary-foreground text-xs font-medium">
-            <CheckSquare size={14} />
-            <span>{selectedUids.size} selected</span>
+        <div className="px-3 py-2 bg-primary text-primary-foreground flex items-center justify-between gap-2 flex-shrink-0">
+          <div className="flex items-center gap-2 text-xs min-w-0">
+            <span className="font-medium whitespace-nowrap">{selectedUids.size} selected</span>
+            <button
+              onClick={allEligibleSelected ? onClearSelection : onSelectAll}
+              className="text-primary-foreground/80 hover:text-primary-foreground underline-offset-2 hover:underline whitespace-nowrap"
+            >
+              {allEligibleSelected ? 'Clear' : 'Select all'}
+            </button>
           </div>
-          <div className="flex items-center gap-1.5">
-            <Button size="sm" variant="secondary" className="h-7 text-xs px-2" disabled={selectedUids.size === 0} onClick={onOpenBulkUpdate}>Assign Site</Button>
-            <Button size="sm" variant="secondary" className="h-7 text-xs px-2" disabled={selectedUids.size === 0} onClick={onOpenBulkSpeciesEdit}>Species</Button>
-            <Button size="sm" variant="secondary" className="h-7 text-xs px-2" disabled={selectedUids.size === 0} onClick={onOpenBulkStartDateEdit}>Date</Button>
-            <button onClick={onExitBulkMode} className="p-1 text-primary-foreground/80 hover:text-primary-foreground transition-colors">
+          <div className="flex items-center gap-0.5">
+            {[
+              { title: 'Assign site', icon: MapPin, onClick: onOpenBulkUpdate },
+              { title: 'Edit species', icon: Leaf, onClick: onOpenBulkSpeciesEdit },
+              { title: 'Edit date', icon: Calendar, onClick: onOpenBulkStartDateEdit },
+            ].map(({ title, icon: Icon, onClick }) => (
+              <button
+                key={title}
+                title={title}
+                aria-label={title}
+                disabled={selectedUids.size === 0}
+                onClick={onClick}
+                className="flex items-center justify-center h-7 w-7 rounded hover:bg-primary-foreground/15 disabled:opacity-40 disabled:hover:bg-transparent transition-colors"
+              >
+                <Icon size={14} />
+              </button>
+            ))}
+            <span className="mx-0.5 h-4 w-px bg-primary-foreground/25" />
+            <button onClick={onExitBulkMode} title="Exit selection" aria-label="Exit selection" className="flex items-center justify-center h-7 w-7 rounded hover:bg-primary-foreground/15 transition-colors">
               <X size={14} />
             </button>
           </div>
@@ -198,19 +311,20 @@ export const InterventionsPanel = ({
             )}
           </div>
         ) : (
-          <div className="p-3 space-y-2">
+          <div ref={listRef} className="p-3 space-y-2">
             {interventions.map((intervention) => (
-              <InterventionCard
-                key={intervention.id}
-                intervention={intervention}
-                isSelected={selectedIntervention?.id === intervention.id}
-                onClick={() => onSelect(intervention)}
-                isMultiSelectMode={isBulkMode}
-                isChecked={selectedUids.has(intervention.uid)}
-                onToggleSelect={(e) => { e.stopPropagation(); onToggleSelect(intervention.uid) }}
-                isDisabled={isBulkMode && lockedType !== null && intervention.type !== lockedType}
-                disabledTooltip="Bulk edit requires same intervention type"
-              />
+              <div key={intervention.id} data-uid={intervention.uid}>
+                <InterventionCard
+                  intervention={intervention}
+                  isSelected={selectedIntervention?.id === intervention.id}
+                  onClick={() => onSelect(intervention)}
+                  isMultiSelectMode={isBulkMode}
+                  isChecked={selectedUids.has(intervention.uid)}
+                  onToggleSelect={(e) => { e.stopPropagation(); onToggleSelect(intervention.uid, e.shiftKey) }}
+                  isDisabled={isBulkMode && lockedType !== null && intervention.type !== lockedType}
+                  disabledTooltip="Bulk edit requires same intervention type"
+                />
+              </div>
             ))}
 
             {hasMore && (
@@ -223,7 +337,7 @@ export const InterventionsPanel = ({
 
             {!hasMore && interventions.length > 0 && (
               <div className="py-4 text-center">
-                <p className="text-xs text-muted-foreground/70">Showing all {pagination.total} results</p>
+                <p className="text-xs text-muted-foreground/70">Showing all {total.toLocaleString('en-US')} results</p>
               </div>
             )}
           </div>

--- a/apps/web/src/app/(dashboard)/project/[projectUid]/intervention/page.tsx
+++ b/apps/web/src/app/(dashboard)/project/[projectUid]/intervention/page.tsx
@@ -280,16 +280,68 @@ const TreeMapperUI = () => {
     router.replace(`?id=${intervention.uid}`, { scroll: false });
   };
 
-  const handleToggleSelect = (uid: string) => {
+  // Arrow up/down move through the list when not in bulk-select mode.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (isBulkMode || (e.key !== 'ArrowDown' && e.key !== 'ArrowUp')) return;
+      const el = e.target as HTMLElement | null;
+      if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
+      if (interventions.length === 0) return;
+      e.preventDefault();
+      const idx = interventions.findIndex(i => i.uid === selectedIntervention?.uid);
+      const next = e.key === 'ArrowDown'
+        ? (idx < 0 ? 0 : Math.min(idx + 1, interventions.length - 1))
+        : (idx < 0 ? 0 : Math.max(idx - 1, 0));
+      const target = interventions[next];
+      if (target && target.uid !== selectedIntervention?.uid) handleSelectIntervention(target);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [interventions, selectedIntervention, isBulkMode]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Anchor for shift+click range selection.
+  const lastSelectedUidRef = useRef<string | null>(null);
+
+  const handleToggleSelect = (uid: string, shiftKey = false) => {
+    const anchor = lastSelectedUidRef.current;
+    if (shiftKey && anchor && anchor !== uid) {
+      const order = interventions.map(i => i.uid);
+      const a = order.indexOf(anchor);
+      const b = order.indexOf(uid);
+      if (a !== -1 && b !== -1) {
+        const [lo, hi] = a < b ? [a, b] : [b, a];
+        // Keep the range to a single type (anchor's), since bulk edits require it.
+        const rangeType = lockedType ?? interventions[a]?.type;
+        setSelectedUids(prev => {
+          const next = new Set(prev);
+          for (let k = lo; k <= hi; k++) {
+            const it = interventions[k];
+            if (!rangeType || it.type === rangeType) next.add(it.uid);
+          }
+          return next;
+        });
+        lastSelectedUidRef.current = uid;
+        return;
+      }
+    }
     setSelectedUids(prev => {
       const next = new Set(prev);
       if (next.has(uid)) next.delete(uid); else next.add(uid);
       return next;
     });
+    lastSelectedUidRef.current = uid;
   };
 
-  const handleEnterBulkMode = () => { setIsBulkMode(true); setSelectedUids(new Set()); };
-  const handleExitBulkMode = () => { setIsBulkMode(false); setSelectedUids(new Set()); };
+  const handleEnterBulkMode = () => { setIsBulkMode(true); setSelectedUids(new Set()); lastSelectedUidRef.current = null; };
+  const handleExitBulkMode = () => { setIsBulkMode(false); setSelectedUids(new Set()); lastSelectedUidRef.current = null; };
+  const handleClearSelection = () => { setSelectedUids(new Set()); lastSelectedUidRef.current = null; };
+  // Select all visible interventions of the locked type (or the first item's
+  // type when nothing is selected yet), since bulk edits require one type.
+  const handleSelectAll = () => {
+    const type = lockedType ?? interventions[0]?.type;
+    if (!type) return;
+    setSelectedUids(new Set(interventions.filter(i => i.type === type).map(i => i.uid)));
+  };
   const handleBulkUpdateComplete = () => { handleExitBulkMode(); fetchInterventionData(pagination.page); };
 
   const handleInterventionDelete = async () => {
@@ -335,6 +387,8 @@ const TreeMapperUI = () => {
           onToggleSelect={handleToggleSelect}
           onEnterBulkMode={handleEnterBulkMode}
           onExitBulkMode={handleExitBulkMode}
+          onSelectAll={handleSelectAll}
+          onClearSelection={handleClearSelection}
           onOpenBulkUpdate={() => setShowBulkUpdateModal(true)}
           onOpenBulkSpeciesEdit={() => setShowBulkSpeciesModal(true)}
           onOpenBulkStartDateEdit={() => setShowBulkStartDateModal(true)}

--- a/apps/web/src/component/sidebar/DashboardSidebar.tsx
+++ b/apps/web/src/component/sidebar/DashboardSidebar.tsx
@@ -349,6 +349,7 @@ export default function DashboardSidebar({ createNewProject, openProfileSetting,
                     onClick={() => item.id === 'impersonate' ? setImpersonateOpen(true) : handleNavClick(item.id)}
                     isActive={activeRoute === item.id}
                     tooltip={item.label}
+                    className="data-[active=true]:!bg-primary/10 data-[active=true]:!text-primary data-[active=true]:!font-medium"
                   >
                     <item.icon />
                     <span>{item.label}</span>


### PR DESCRIPTION
Polishes the intervention records page (web) - card layout, filter UI, and bulk-select interactions.

Changes

- Card: fixed the icon box stretching when flagged; title + HID on the left, capture status as a cloud icon (CloudCheck/Cloud) on the right; date, trees and species on one line; tree count as the headline for tree-registration types; full date with year; thousand-separated counts.

- Filters: four dropdowns collapsed into one Filter popover (Type, Site, Capture mode) with an active-count badge and removable chips; Flag is now an independent toggle next to sort (all → flagged → not flagged).

- Bulk select: lean single-row action bar (count, Select all / Clear, icon actions); shift+click range select; arrow up/down move through the list when not selecting.

Sidebar: active nav item now 

- [ ] shows in brand green instead of gray.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tree markers to intervention maps
  * Added keyboard navigation (arrow keys) for intervention list
  * Added shift+click range selection and "select all" action for bulk operations

* **Improvements**
  * Reorganized filter controls into a popover panel with removable filter chips
  * Enhanced intervention details view with collapsible sections and clearer formatting
  * Updated capture status display with cloud icons and badges
  * Improved date and intervention title formatting for tree registrations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Plant-for-the-Planet-org/treemapper/pull/1032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->