### PR TITLE
feat(web): urban greening options in onboarding & create-project

### DIFF
--- a/apps/web/src/app/(standalone)/create-project/page.tsx
+++ b/apps/web/src/app/(standalone)/create-project/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Leaf, MapPin, Globe, Info, FileText, ArrowLeft, Loader2, TreePine, Target, Shield, Plus } from 'lucide-react';
+import { Leaf, MapPin, Globe, Info, FileText, ArrowLeft, Loader2, TreePine, Target, Shield, Plus, Building2 } from 'lucide-react';
 import ProjectMap from '@/component/MapSelect';
 import { toast } from 'react-toastify'
 import { createNewProject } from '@shared-core/fetchApi/api.fetch';
@@ -113,6 +113,7 @@ const ProjectTypeSelector = ({ value, onChange, projectTypes }) => {
                             htmlFor={`type-${type.id}`}
                             className={cn(
                                 'relative flex cursor-pointer items-start gap-2.5 rounded-lg border p-3 transition-colors font-normal',
+                                type.id === 'other' && 'col-span-2',
                                 selected ? 'border-primary bg-primary/5' : 'border-border hover:bg-muted/40'
                             )}
                         >
@@ -436,6 +437,12 @@ export function CreateProjectUI() {
             label: 'Conservation',
             icon: Shield,
             description: 'Habitat protection',
+        },
+        {
+            id: 'urban-tree-planting',
+            label: 'Urban Tree Planting',
+            icon: Building2,
+            description: 'Greening urban spaces',
         },
         {
             id: 'other',

--- a/apps/web/src/app/(standalone)/onboard/components/screenTwo.tsx
+++ b/apps/web/src/app/(standalone)/onboard/components/screenTwo.tsx
@@ -40,6 +40,7 @@ export const ScreenTwo = ({ onNext, onBack, loading }) => {
     'Research & Data Collection',
     'Environmental Education',
     'Land Use Planning',
+    'Greening Urban Spaces',
     'Other'
   ];
 


### PR DESCRIPTION
## What

Two small additions aimed at identifying and supporting **urban greening** users:

**Onboarding, Primary Goal** (`onboard/components/screenTwo.tsx`)
- Adds **Greening Urban Spaces** as a Primary Goal option (before "Other").

**Create Project, Project Type** (`create-project/page.tsx`)
- Adds **Urban Tree Planting** (Building2 icon) right after Conservation.
- Makes **Other** a full-width option so it sits cleanly on its own row.

## Why

Gives us a signal to spot organizations using TreeMapper for cities / urban greening, both at signup and at project creation.

## Notes

Based on `develop` (the onboarding screen is live on `develop`, not `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Urban Tree Planting” as a selectable project type.
  * Added “Greening Urban Spaces” as an onboarding goal option.
  * Improved the project type selector layout for the “Other” option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->