### PR TITLE
fix(species): honour limit, search common names, always return an array

### DIFF
--- a/apps/server/src/species/controller/scientific-species.controller.ts
+++ b/apps/server/src/species/controller/scientific-species.controller.ts
@@ -32,8 +32,8 @@ export class ScientificSpeciesController {
 
 
   @Get('search')
-  getProjectInviteStatus(
+  searchSpecies(
     @Query() queryDto: SearchSpeciesQueryDto) {
-    return this.scientificSpeciesService.searchSpecies(queryDto.name);
+    return this.scientificSpeciesService.searchSpecies(queryDto.name, queryDto.limit);
   }
 }

--- a/apps/server/src/species/services/scientific-species.service.ts
+++ b/apps/server/src/species/services/scientific-species.service.ts
@@ -81,19 +81,18 @@ export class ScientificSpeciesService {
   }
 
   async searchSpecies(searchTerm: string, limit: number = 10) {
+    // Always an array, whatever the input. The old empty-term branch returned
+    // an object instead, so a caller doing `results.map(...)` crashed rather
+    // than seeing no matches.
+    const trimmedSearch = searchTerm?.trim();
+    if (!trimmedSearch) {
+      return [];
+    }
+
+    const prefix = `${trimmedSearch}%`;
+    const anywhere = `%${trimmedSearch}%`;
+
     try {
-      // Trim and validate search term
-      const trimmedSearch = searchTerm.trim();
-
-      if (!trimmedSearch) {
-        return {
-          success: false,
-          message: 'Search term cannot be empty',
-          data: [],
-          count: 0,
-        };
-      }
-
       const species = await this.drizzle.db
         .select({
           id: scientificSpecies.id,
@@ -103,9 +102,23 @@ export class ScientificSpeciesService {
           description: scientificSpecies.description,
         })
         .from(scientificSpecies)
-        .where(ilike(scientificSpecies.scientificName, `%${trimmedSearch}%`))
+        // Common names are searched too. People look up a tree by the name they
+        // know it by, and we return `commonName` in the result, so not matching
+        // on it left an obvious search coming back empty.
+        .where(
+          or(
+            ilike(scientificSpecies.scientificName, anywhere),
+            ilike(scientificSpecies.commonName, anywhere),
+          ),
+        )
+        // Names that start with the term rank above ones that merely contain it,
+        // scientific name first, so typing "Quer" leads with Quercus.
         .orderBy(
-          sql`CASE WHEN ${scientificSpecies.scientificName} ILIKE ${trimmedSearch + '%'} THEN 0 ELSE 1 END`,
+          sql`CASE
+            WHEN ${scientificSpecies.scientificName} ILIKE ${prefix} THEN 0
+            WHEN ${scientificSpecies.commonName} ILIKE ${prefix} THEN 1
+            ELSE 2
+          END`,
           asc(scientificSpecies.scientificName),
         )
         .limit(limit);


### PR DESCRIPTION
Fixes three defects in `GET /api/scientific-species/search`.

These came out of an assessment of whether the Plant-for-the-Planet web app can
retire its current species lookup and use this endpoint instead. That
assessment is written up at the bottom, since it is the reason these fixes
matter and it records what a consumer needs to know.

## What was wrong

**`limit` was accepted and then dropped.** The DTO declares `limit`, validates
it between 1 and 100, and defaults it to 10. The controller called
`searchSpecies(queryDto.name)` and never passed it. Every search returned at
most 10 rows regardless of what the caller asked for.

**Common names were not searched.** The query matched `scientificName` only,
even though `commonName` is selected and returned in the response, and the
sibling `getAll` matches both. Someone searching by the name they actually know
a tree by got an empty result.

**An empty term returned the wrong shape.** Every other path returns an array;
a blank term returned `{success, message, data, count}`. A caller doing
`results.map(...)` crashed instead of seeing no matches. The DTO's
`@IsNotEmpty()` means this only ever bit internal callers, not HTTP ones, but
the inconsistency is a trap.

## What changed

- The controller passes `limit` through, so the parameter now does what it says.
- The `WHERE` clause matches `scientificName` **or** `commonName`.
- Ordering ranks a scientific-name prefix first, then a common-name prefix,
  then anything that merely contains the term, alphabetical within each band.
  Typing `Quer` leads with `Quercus`.
- A blank term returns `[]`.
- The route handler is renamed from `getProjectInviteStatus`, copy-pasted from
  another controller, to `searchSpecies`.

## Testing

Typecheck passes. No unit tests were added: the repo currently has no `.spec.ts`
files beyond the default e2e scaffold, so there is no mocking pattern for
`DrizzleService` to follow. The relevance ordering is the kind of thing worth
pinning down, so if the team wants the first service unit test here, say so and
I will add it along with the Drizzle mock.

Not verified: whether `scientific_species` is populated, and with what. That
needs a look at the database, not the code.

---

# Assessment: can the web app use this endpoint?

The web app currently calls a legacy `suggest.php` species lookup on the older
backend. It uses it in two places. Short answer: one can switch today, the
other is blocked on a data question.

## Compatible

**Authentication already works.** A global JWT guard covers this route, and it
is not marked `@Public()`, so a token is required. The token is validated
against the same Auth0 tenant and audience the web app already authenticates
against, so the web app's existing access token is accepted with no changes.
Both species call sites sit behind login, so requiring a token costs nothing.

**Relevance is better.** Results come back ranked and alphabetised, so the
client-side sort the web app does today becomes redundant.

**More data.** The response carries `commonName` and `description` on top of
the scientific name.

## Differences a consumer must handle

1. **Responses are wrapped.** The global `ResponseInterceptor` returns
   `{statusCode, message, error, data, code}`. Only `/api/external/*` is
   exempt. Callers need to unwrap `.data`.
2. **Method and parameter differ** from the legacy lookup: `GET` rather than
   `POST`, and `name` rather than `q`.
3. **`id` is a serial integer and `uid` is the GUID.** Anything that persists
   an identifier wants `uid`, not `id`.

## The blocker

One of the two web app call sites stores its own species records against the
older backend, sending it the selected species identifier. That identifier has
to be one the older backend recognises. This table's `uid` is populated from a
`guid` field on the bulk-upload path, which suggests identifiers were imported
from there, but nothing in either repository confirms that the table is
populated or that the values line up.

Until someone checks the database, only the call site that stores a plain
scientific name and no identifier can switch safely.

## Two side effects worth knowing

- **This endpoint provisions users.** JWT validation creates a TreeMapper user
  record for any verified-email token it has not seen before. Calling it from
  another product will quietly create user rows for everyone who touches a
  species field there.
- **The issuer is pinned.** Any consumer whose environment points at a
  different Auth0 domain than the one this server expects will fail validation,
  even with a valid token from the same tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scientific species search with support for result limits.
  * Searches both scientific and common names, prioritizing relevant prefix matches.
  * Results are ordered alphabetically, with scientific-name matches ranked first.

* **Bug Fixes**
  * Empty or whitespace-only searches now return no results instead of an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->